### PR TITLE
Issue #12   stock names look up

### DIFF
--- a/include/rawpheno.admin.form.inc
+++ b/include/rawpheno.admin.form.inc
@@ -265,11 +265,30 @@ function rawpheno_admin_all_projects($form, &$form_state) {
       '#description' => t('Please note that column headers Plot, Entry, Rep, Name, Location and Planting Date (date) are added to project by default.'),
     );
 
-    $form['fieldset_sel_project']['add_project'] = array(
-      '#type' => 'submit',
-      '#value' => t('Create Project'),
-      '#id' => 'admin-add-project',
-    );
+    // Fetch genus.
+    // NOTE: saving genus cvterm instead of the organism.
+    $sql = "SELECT genus, UPPER(genus) FROM {organism} GROUP BY genus ORDER BY genus";
+    $g = chado_query($sql);
+
+    if ($g->rowCount() > 0) {
+      $genus = $g->fetchAllKeyed();
+      $genus_options = array('' => '---') + $genus;
+
+      // List genus - select box to select genus the project is collecting data for/to.
+      $form['fieldset_sel_project']['sel_genus'] = array(
+        '#type' => 'select',
+        '#title' => t('Project is collecting data for genus:'),
+        '#options' => $genus_options,
+        '#default_value' => array_keys($genus_options)[0],
+        '#id' => 'admin-sel-genus',
+      );
+
+      $form['fieldset_sel_project']['add_project'] = array(
+        '#type' => 'submit',
+        '#value' => t('Create Project'),
+        '#id' => 'admin-add-project',
+      );
+    }
   }
   else {
     $form['fieldset_sel_project']['no_project'] = array(
@@ -310,7 +329,7 @@ function rawpheno_admin_all_projects($form, &$form_state) {
             t1.project_id IN (SELECT DISTINCT project_id FROM pheno_project_cvterm)
             AND t2.project_id IN (SELECT DISTINCT project_id FROM pheno_project_cvterm)
             AND t3.project_id IN (SELECT DISTINCT project_id FROM pheno_project_cvterm)
-            AND t3.type = 'essential'
+            AND t3.type = :essential_trait
             AND t4.project_id IN (SELECT DISTINCT project_id FROM pheno_project_cvterm)
           GROUP BY t1.project_id
           ORDER BY t1.project_id DESC";
@@ -330,6 +349,25 @@ function rawpheno_admin_all_projects($form, &$form_state) {
     $i = 0;
 
     foreach($projects as $p) {
+      // Fetch project genus.
+      $project_prop = rawpheno_function_project_organism($p->project_id, 'full');
+      $project_genus = $project_prop['genus'];
+
+      // Markup the genus.
+      if (empty($project_genus)) {
+        // Warn admin no organism set.
+        $markup_project_genus = '<img src="../../../../misc/message-16-warning.png" title="Project genus not set." alt="Project genus not set." /> Not set';
+        $project_organism_markup = '';
+      }
+      else {
+        // Display genus.
+        $markup_project_genus = '<div class="tag-name more-info" id="prj' . $p->project_id . '">' . $project_genus . '</div>';
+
+        // Project genus organism.
+        $project_organism = array_values($project_prop['organism']);
+        $project_organism_markup = '<span id="genus-list-prj'. $p->project_id .'" class="hover-more-info">' . implode(', ', $project_organism) . '</span>';
+      }
+
       $view_link = 'admin/tripal/extension/rawphenotypes/all_projects/' . $p->project_id . '/project/manage';
       $view_cell = l('View', $view_link);
       $name_cell = l($p->name, $view_link);
@@ -344,9 +382,17 @@ function rawpheno_admin_all_projects($form, &$form_state) {
         ? ''
         : '&nbsp;&nbsp;<img src="../../../../misc/message-16-warning.png" title="Project has no assigned user" alt="Project has no assigned user" />';
 
-
       // + 1 to account for Name column header.
-      array_push($arr_rows, array(($i+1), $name_cell, ($p->header_count + 1), $p->essential_count . $warn_header, $p->user_count . $warn_user, $view_cell));
+      $arr_rows[] = array(
+        ($i+1),                                           // Row counter.
+        $name_cell,                                       // Project name/title.
+        $markup_project_genus . $project_organism_markup, // Project genus and project oranism.
+        ($p->header_count + 1),                           // Traits count.
+        $p->essential_count . $warn_header,               // Essential traits count.
+        $p->user_count . $warn_user,                      // User count.
+        $view_cell                                        // View project assets link.
+      );
+
       $i++;
     }
   }
@@ -355,9 +401,16 @@ function rawpheno_admin_all_projects($form, &$form_state) {
   }
 
   // Table headers.
-  array_push($arr_headers, '-', t('Project Name'), t('Column Headers'), t('Essential Headers'), t('Active User'), t('View'));
+  array_push($arr_headers, '-', t('Project Name'), t('Genus/Organism'), t('Column Headers'), t('Essential Headers'), t('Active User'), t('View'));
 
-  $table = theme('table', array('header' => $arr_headers, 'rows' => $arr_rows, 'empty' => $empty_table_title));
+  $table = theme('table',
+    array(
+      'header' => $arr_headers,
+      'rows' => $arr_rows,
+      'empty' => $empty_table_title,
+      'attributes' => array('id' => 'rawphenotypes-project'),
+    )
+  );
 
   // Render table.
   $form['tbl_projects'] = array(
@@ -367,6 +420,7 @@ function rawpheno_admin_all_projects($form, &$form_state) {
   // Attach css.
   $path = drupal_get_path('module', 'rawpheno') . '/theme/';
   $form['#attached']['css'] = array($path . 'css/rawpheno.admin.style.css');
+  $form['#attached']['js'] = array($path . 'js/rawpheno.admin.script.js');
 
   return $form;
 }
@@ -380,6 +434,11 @@ function rawpheno_admin_all_projects_validate($form, &$form_state) {
   $project_id = $form_state['values']['sel_project'];
   if ($project_id <= 0) {
     form_set_error('sel_project', t('No project selected. Please select a project and try again'));
+  }
+
+  $genus = $form_state['values']['sel_genus'];
+  if (empty($genus)) {
+    form_set_error('sel_organism', t('No genus selected. Please select genus and try again'));
   }
 }
 
@@ -449,6 +508,27 @@ function rawpheno_admin_all_projects_submit($form, &$form_state) {
     ->execute();
   }
 
+  // Link genus and project in projectprop.
+  $genus = $form_state['values']['sel_genus'];
+  // Ensure that only the first letter is capitalized.
+  $genus = ucfirst($genus);
+
+  // Get genus/organism controlled vocabulary term.
+  // Term.
+  $term = rawpheno_function_organism_cv();
+  $genus_cvterm = tripal_get_cvterm($term);
+
+  if ($genus_cvterm) {
+    db_insert('chado.projectprop')
+      ->fields(array(
+        'project_id' => $project_id,
+        'type_id' => $genus_cvterm->cvterm_id,
+        'value' => $genus,
+        'rank' => 0,
+        )
+      )
+      ->execute();
+  }
 
   // Redirect user to project asset management page.
   $path = url('../../admin/tripal/extension/rawphenotypes/all_projects/' . $project_id . '/project/manage');

--- a/include/rawpheno.admin.form.inc
+++ b/include/rawpheno.admin.form.inc
@@ -25,7 +25,8 @@ function rawpheno_admin_main_page($form, &$form_state) {
   return $form;
 }
 
- /**
+
+/**
  * Function callback: Construct administrative interface to modify page title and colour scheme.
  */
 function rawpheno_admin_page($form, &$form_state) {
@@ -134,6 +135,8 @@ module_load_include('inc', 'rawpheno', 'include/rawpheno.function.measurements')
 
 /**
  * Function callback: Construct administrative interface to manage R Friendly transformation of column headers.
+ *
+ * @see rawpheno_admin_rheaders_validate().
  */
 function rawpheno_admin_rheaders($form, &$form_state) {
   $breadcrumbs = array();
@@ -192,29 +195,142 @@ function rawpheno_admin_rheaders($form, &$form_state) {
 
 
 /**
- * Implements hook_validate().
- * Ensure that the match and replace entry is in match value = replace value format.
+ * Function callback: Construct form to manage project assets.
+ *
+ * @param $asset_id
+ *   An integer containing the record id.
+ * @param $asset_type
+ *   A string indicating what asset type the id is, a project, a user or a column header.
+ * @param $action
+ *   A string containing predefined commands performed to an asset.
+ *
+ * @see rawpheno_admin_project_management_validate().
+ * @see rawpheno_admin_project_management_submit().
  */
-function rawpheno_admin_rheaders_validate($form, &$form_state) {
-  // Read string containing the match and replace rule. Since each pair is separated by comma symbol,
-  // use it to split and process each entry. In each item, test if both match value and replace value are provided,
-  // by examining the value before and after the = sign. When a pair is missing either values, send an
-  // error message to admin that an entry is not in the prescribed format.
-  $mr = trim($form_state['values']['rawpheno_rtransform_replace']);
+function rawpheno_admin_project_management($form, &$form_state, $asset_id = NULL, $asset_type = NULL, $action = NULL) {
+  // Link to go back.
+  $goback = '&nbsp;<a href="javascript:history.back();">Go back</a>';
 
-  $match_replace = explode(',', $mr);
-  foreach($match_replace as $r) {
-    @list($match, $replace) = explode('=', $r);
-    if (empty(trim($match)) OR empty(trim($replace))) {
-      form_set_error('rawpheno_rtransform_replace', t('An entry not in the required format (Match value = Replace value) was found.'));
+  // Define valid action/command/operation per asset type.
+  $arr_valid = array();
+  $arr_valid['project']['command'] = array('manage');
+  $arr_valid['project']['table'] = 'pheno_project_cvterm';
+  $arr_valid['project']['id'] = 'project_id';
+
+  $arr_valid['header']['command'] = array('edit', 'delete');
+  $arr_valid['header']['table'] = 'pheno_project_cvterm';
+  $arr_valid['header']['id'] = 'project_cvterm_id';
+
+  $arr_valid['user']['command'] = array('delete');
+  $arr_valid['user']['table'] = 'pheno_project_user';
+  $arr_valid['user']['id'] = 'project_user_id';
+
+  // Ensure query strings are valid. The string length check ensure that Posgres
+  // will not throw Numeric value out of range PDOexception.
+  if (!isset($asset_id) OR $asset_id <= 0 OR strlen($asset_id) >= 10) {
+    // When project asset id is invalid.
+    drupal_set_message(t('Not a valid project asset id number.') . $goback, 'error');
+  }
+  else {
+    // Id is valid, test if asset type is valid.
+    if (array_key_exists($asset_type, $arr_valid)) {
+      // Valid asset type request. Check if the given asset id and asset type
+      // exists in the database before peforming any command.
+      $sql = sprintf("SELECT FROM {%s} WHERE %s = :asset_id LIMIT 1",
+        $arr_valid[$asset_type]['table'], $arr_valid[$asset_type]['id']);
+
+      $args = array(':asset_id' => (int)$asset_id);
+      $prj_asset = db_query($sql, $args);
+
+      if ($prj_asset->rowCount() == 1) {
+        // Project asset exists in the database. Procede to command requested.
+        // Determine what to do with the project asset.
+        if (in_array($action, $arr_valid[$asset_type]['command'])) {
+          // Command is valid. Call function that will execute the command.
+          if ($asset_type == 'project') {
+            // Call project function.
+            $form = rawpheno_admin_project($form, $form_state, $asset_id);
+          }
+          elseif ($asset_type == 'header') {
+            ///////////
+            // Before admin can modify or delete a column header, ensure that a header
+            // is not a plant property type header, not used by another project and the header has no data associated to it.
+            // In addition, Loding (scale 1-5) header is not editable.
+            $trait_type = rawpheno_function_trait_types();
+            $plant_property = $trait_type['type4'];
+
+            // Get header properties.
+            $header_asset = rawpheno_function_header_properties($asset_id, 'full');
+
+            if ($header_asset['count_data'] > 0 AND $action == 'delete') {
+              // Header has data.
+              drupal_set_message(t('Cannot @action this entry. Column header has data associated to it.',
+                array('@action' => $action)) . $goback, 'error');
+            }
+            else {
+              // Call header function.
+              $form = rawpheno_admin_project_headers($form, $form_state, $header_asset, $action);
+            }
+            ///////////
+          }
+          else if($asset_type == 'user') {
+            ///////////
+            // Ensure that user is not deleted when there is data and backup files associated.
+            $user_project_asset = rawpheno_admin_user_assets($asset_id);
+
+            if ($user_project_asset['project_file_count'] > 0) {
+              // User is assigned to a project has backup files.
+              drupal_set_message(t('Cannot @action this user. User has backup files.',
+                array('@action' => $action)) . $goback, 'error');
+            }
+            elseif ($user_project_asset['project_data_count'] > 0) {
+              // User is assigned to a project has has data.
+              drupal_set_message(t('Cannot @action this user. User is assigned to a project that has data.',
+                array('@action' => $action)) . $goback, 'error');
+            }
+            elseif ($user_project_asset['user_id'] < 2) {
+              // User is administrator.
+              drupal_set_message(t('Cannot @action user. The user is administrator of this site.',
+                array('@action' => $action)) . $goback, 'error');
+            }
+            else {
+              // Call user function.
+              $form = rawpheno_admin_project_users($form, $form_state, $user_project_asset, $action);
+            }
+            ////////////
+          }
+        }
+        else {
+          // Not a valid command.
+          drupal_set_message(t('Not a valid request.' . $goback), 'error');
+        }
+      }
+      else {
+        // Asset record not found.
+        drupal_set_message(t('Project asset id number does not exist.' . $goback), 'error');
+      }
+    }
+    else {
+      // Asset type does not exist.
+      drupal_set_message(t('Not a valid project request.' . $goback), 'error');
     }
   }
+
+  // Attach css and javascript.
+  $path = drupal_get_path('module', 'rawpheno') . '/theme/';
+  $form['#attached']['css'] = array($path . 'css/rawpheno.admin.style.css');
+  $form['#attached']['js'] = array($path . 'js/rawpheno.admin.script.js');
+
+  return $form;
 }
 
 
 /**
  * Function callback: Construct form to list all active projects (with headers and users)
  * and allow admin to create a new project.
+ *
+ * @see rawpheno_admin_all_projects_validate().
+ * @see rawpheno_admin_all_projects_submit().
  */
 function rawpheno_admin_all_projects($form, &$form_state) {
   $breadcrumbs = array();
@@ -427,248 +543,18 @@ function rawpheno_admin_all_projects($form, &$form_state) {
 
 
 /**
- * Implements hook_validate().
- * Ensure that a project is selected when creating a new project.
- */
-function rawpheno_admin_all_projects_validate($form, &$form_state) {
-  $project_id = $form_state['values']['sel_project'];
-  if ($project_id <= 0) {
-    form_set_error('sel_project', t('No project selected. Please select a project and try again'));
-  }
-
-  $genus = $form_state['values']['sel_genus'];
-  if (empty($genus)) {
-    form_set_error('sel_organism', t('No genus selected. Please select genus and try again'));
-  }
-}
-
-
-/**
- * Implements hook_sumbit().
- * Create a new project.
- */
-function rawpheno_admin_all_projects_submit($form, &$form_state) {
-  // When a new project is created, Plant property column headers are
-  // added to a project by default. The following are the plant property headers:
-  // Location, Plot Rep and Entry.
-
-  // Plus and Planting Date and make it essential trait. Planting date is important
-  // as it is used when generating the heatmap.
-  $project_id = $form_state['values']['sel_project'];
-
-  // Get trait types array.
-  $trait_type = rawpheno_function_trait_types();
-
-  // Get Planting Date cvterm id.
-  $planting_date = tripal_get_cvterm(array('name' => 'Planting Date (date)',
-                                     'cv_id' => array('name' => 'phenotype_measurement_types')));
-
-  db_insert('pheno_project_cvterm')
-    ->fields(array(
-      'project_id' => $project_id,
-      'cvterm_id' => $planting_date->cvterm_id,
-      'type' => $trait_type['type1'])
-    )
-  ->execute();
-
-  // Query all plant property types column headers in chado.cvterm table.
-  $sql = "SELECT cvterm_id
-          FROM {cv} AS t1 INNER JOIN {cvterm} AS t2 USING(cv_id)
-          WHERE t1.name = 'phenotype_plant_property_types'
-          ORDER BY cvterm_id ASC";
-
-  $pp = chado_query($sql);
-
-  // Test each plant property if it is present in the project.
-  foreach($pp as $t) {
-    db_insert('pheno_project_cvterm')
-      ->fields(array(
-        'project_id' => $project_id,
-        'cvterm_id' => $t->cvterm_id,
-        'type' => $trait_type['type4'])
-      )
-    ->execute();
-  }
-
-  // Make who created the project as the default user.
-  db_insert('pheno_project_user')
-    ->fields(array(
-      'project_id' => $project_id,
-      'uid' => $GLOBALS['user']->uid)
-    )
-  ->execute();
-
-  if ($GLOBALS['user']->uid != 1) {
-    // If the user is not the superadmin, add as well.
-    db_insert('pheno_project_user')
-      ->fields(array(
-        'project_id' => $project_id,
-        'uid' => 1)
-      )
-    ->execute();
-  }
-
-  // Link genus and project in projectprop.
-  $genus = $form_state['values']['sel_genus'];
-  // Ensure that only the first letter is capitalized.
-  $genus = ucfirst($genus);
-
-  // Get genus/organism controlled vocabulary term.
-  // Term.
-  $term = rawpheno_function_organism_cv();
-  $genus_cvterm = tripal_get_cvterm($term);
-
-  if ($genus_cvterm) {
-    db_insert('chado.projectprop')
-      ->fields(array(
-        'project_id' => $project_id,
-        'type_id' => $genus_cvterm->cvterm_id,
-        'value' => $genus,
-        'rank' => 0,
-        )
-      )
-      ->execute();
-  }
-
-  // Redirect user to project asset management page.
-  $path = url('../../admin/tripal/extension/rawphenotypes/all_projects/' . $project_id . '/project/manage');
-  drupal_goto($path);
-}
-
-
-/**
- * Function callback: Construct form to manage project assets.
- *
- * @param $asset_id
- *   An integer containing the record id.
- * @param $asset_type
- *   A string indicating what asset type the id is, a project, a user or a column header.
- * @param $action
- *   A string containing predefined commands performed to an asset.
- */
-function rawpheno_admin_project_management($form, &$form_state, $asset_id = NULL, $asset_type = NULL, $action = NULL) {
-  // Link to go back.
-  $goback = '&nbsp;<a href="javascript:history.back();">Go back</a>';
-
-  // Define valid action/command/operation per asset type.
-  $arr_valid = array();
-  $arr_valid['project']['command'] = array('manage');
-  $arr_valid['project']['table'] = 'pheno_project_cvterm';
-  $arr_valid['project']['id'] = 'project_id';
-
-  $arr_valid['header']['command'] = array('edit', 'delete');
-  $arr_valid['header']['table'] = 'pheno_project_cvterm';
-  $arr_valid['header']['id'] = 'project_cvterm_id';
-
-  $arr_valid['user']['command'] = array('delete');
-  $arr_valid['user']['table'] = 'pheno_project_user';
-  $arr_valid['user']['id'] = 'project_user_id';
-
-  // Ensure query strings are valid. The string length check ensure that Posgres
-  // will not throw Numeric value out of range PDOexception.
-  if (!isset($asset_id) OR $asset_id <= 0 OR strlen($asset_id) >= 10) {
-    // When project asset id is invalid.
-    drupal_set_message(t('Not a valid project asset id number.') . $goback, 'error');
-  }
-  else {
-    // Id is valid, test if asset type is valid.
-    if (array_key_exists($asset_type, $arr_valid)) {
-      // Valid asset type request. Check if the given asset id and asset type
-      // exists in the database before peforming any command.
-      $sql = sprintf("SELECT FROM {%s} WHERE %s = :asset_id LIMIT 1",
-        $arr_valid[$asset_type]['table'], $arr_valid[$asset_type]['id']);
-
-      $args = array(':asset_id' => (int)$asset_id);
-      $prj_asset = db_query($sql, $args);
-
-      if ($prj_asset->rowCount() == 1) {
-        // Project asset exists in the database. Procede to command requested.
-        // Determine what to do with the project asset.
-        if (in_array($action, $arr_valid[$asset_type]['command'])) {
-          // Command is valid. Call function that will execute the command.
-          if ($asset_type == 'project') {
-            // Call project function.
-            $form = rawpheno_admin_project($form, $form_state, $asset_id);
-          }
-          elseif ($asset_type == 'header') {
-            ///////////
-            // Before admin can modify or delete a column header, ensure that a header
-            // is not a plant property type header, not used by another project and the header has no data associated to it.
-            // In addition, Loding (scale 1-5) header is not editable.
-            $trait_type = rawpheno_function_trait_types();
-            $plant_property = $trait_type['type4'];
-
-            // Get header properties.
-            $header_asset = rawpheno_function_header_properties($asset_id, 'full');
-
-            if ($header_asset['count_data'] > 0 AND $action == 'delete') {
-              // Header has data.
-              drupal_set_message(t('Cannot @action this entry. Column header has data associated to it.',
-                array('@action' => $action)) . $goback, 'error');
-            }
-            else {
-              // Call header function.
-              $form = rawpheno_admin_project_headers($form, $form_state, $header_asset, $action);
-            }
-            ///////////
-          }
-          else if($asset_type == 'user') {
-            ///////////
-            // Ensure that user is not deleted when there is data and backup files associated.
-            $user_project_asset = rawpheno_admin_user_assets($asset_id);
-
-            if ($user_project_asset['project_file_count'] > 0) {
-              // User is assigned to a project has backup files.
-              drupal_set_message(t('Cannot @action this user. User has backup files.',
-                array('@action' => $action)) . $goback, 'error');
-            }
-            elseif ($user_project_asset['project_data_count'] > 0) {
-              // User is assigned to a project has has data.
-              drupal_set_message(t('Cannot @action this user. User is assigned to a project that has data.',
-                array('@action' => $action)) . $goback, 'error');
-            }
-            elseif ($user_project_asset['user_id'] < 2) {
-              // User is administrator.
-              drupal_set_message(t('Cannot @action user. The user is administrator of this site.',
-                array('@action' => $action)) . $goback, 'error');
-            }
-            else {
-              // Call user function.
-              $form = rawpheno_admin_project_users($form, $form_state, $user_project_asset, $action);
-            }
-            ////////////
-          }
-        }
-        else {
-          // Not a valid command.
-          drupal_set_message(t('Not a valid request.' . $goback), 'error');
-        }
-      }
-      else {
-        // Asset record not found.
-        drupal_set_message(t('Project asset id number does not exist.' . $goback), 'error');
-      }
-    }
-    else {
-      // Asset type does not exist.
-      drupal_set_message(t('Not a valid project request.' . $goback), 'error');
-    }
-  }
-
-  // Attach css and javascript.
-  $path = drupal_get_path('module', 'rawpheno') . '/theme/';
-  $form['#attached']['css'] = array($path . 'css/rawpheno.admin.style.css');
-  $form['#attached']['js'] = array($path . 'js/rawpheno.admin.script.js');
-
-  return $form;
-}
-
-
-/**
  * Function callback: Construct interface to manage project asset.
  *
  * @param $project_id
  *   An integer containing the project id number.
+ *
+ * @see rawpheno_admin_validate_update_genus().
+ * @see rawpheno_admin_validate_add_existing().
+ * @see rawpheno_admin_validate_add_user().
+ *
+ * @see rawpheno_admin_submit_update_genus().
+ * @see rawpheno_admin_submit_add_existing().
+ * @see rawpheno_admin_submit_add_user().
  */
 function rawpheno_admin_project($form, &$form_state, $project_id) {
   $breadcrumbs = array();
@@ -1212,152 +1098,25 @@ function rawpheno_admin_project($form, &$form_state, $project_id) {
 }
 
 
-function ajax_rawpheno_filter_users() {
-    return $form['fieldset_users']['tbl_users'];
-}
-
+// VALIDATE.
 
 /**
- * Function callback: Construct form to edit column header and handle deletion.
- *
- * @param $header_asset
- *   An array containing information about a column header.
- * @param $action
- *   A string containing the process to be carried out to a header.
+ * Implements hook_validate().
+ * Ensure that the match and replace entry is in match value = replace value format.
  */
-function rawpheno_admin_project_headers($form, $form_state, $header_asset, $action) {
-  $breadcrumbs = array();
-  $breadcrumbs[] = l('Home', '');
-  $breadcrumbs[] = l('Rawphenotypes', '/admin/tripal/extension/rawphenotypes');
-  $breadcrumbs[] = l('Manage Projects', '/admin/tripal/extension/rawphenotypes/all_projects');
+function rawpheno_admin_rheaders_validate($form, &$form_state) {
+  // Read string containing the match and replace rule. Since each pair is separated by comma symbol,
+  // use it to split and process each entry. In each item, test if both match value and replace value are provided,
+  // by examining the value before and after the = sign. When a pair is missing either values, send an
+  // error message to admin that an entry is not in the prescribed format.
+  $mr = trim($form_state['values']['rawpheno_rtransform_replace']);
 
-  drupal_set_breadcrumb($breadcrumbs);
-
-  // Set the title of this page. This line will create a page title on upper left hand
-  // corner of the page preceding the tabs.
-  drupal_set_title('Manage Project Assets / Update Header');
-
-  if ($action == 'edit') {
-    if ($header_asset['name'] == 'Lodging (Scale: 1-5) upright - lodged' OR $header_asset['name'] == 'Comments') {
-      // Is lodging header.
-      $goback = '&nbsp;<a href="javascript:history.back();">Go back</a>';
-      drupal_set_message(t('Cannot edit @name.', array('@name' => $header_asset['name'])) . $goback, 'error');
+  $match_replace = explode(',', $mr);
+  foreach($match_replace as $r) {
+    @list($match, $replace) = explode('=', $r);
+    if (empty(trim($match)) OR empty(trim($replace))) {
+      form_set_error('rawpheno_rtransform_replace', t('An entry not in the required format (Match value = Replace value) was found.'));
     }
-    else {
-      // Other headers.
-      // CONSTRUCT EDIT FORM.
-
-      // FORM
-      // Add a link to allow administrator to go back to the list of traits in a project.
-      $form['back_link'] = array(
-        '#type' => 'markup',
-        '#markup' => l('Go back to projects table', 'admin/tripal/extension/rawphenotypes/all_projects') . ' | ' . l(t('Go back to project column headers table') ,'admin/tripal/extension/rawphenotypes/all_projects/' . $header_asset['in_project_id'] . '/project/manage'),
-      );
-
-      $form['fieldset_trait'] = array(
-        '#type' => 'fieldset',
-        '#title' => t('Eidt Column Header:'),
-        '#collapsed' => FALSE,
-        '#collapsible' => TRUE,
-      );
-
-      // Trait name field.
-      // Extract the trait rep value, trait unit and the trait name.
-      // NOTE: this can only process header following the format: trait name (trait rep; unit)
-      $trait_rep = $trait_unit = '';
-      // Extract the text value inside the parenthesis (unit part).
-      $t = preg_match("/.*\(([^)]*)\)/", $header_asset['name'], $match);
-      $u = (isset($match[1])) ? $match[1] : '';
-
-      // Extract information in a unit only when there is a unit in the first place.
-      // Get the Trait rep (eg R1, R7, 1st) and measurement unit (eg cm, days) values.
-      $reps = rawpheno_function_trait_reps();
-
-      if ($t) {
-        // Split the information and see if either trait rep or unit is present.
-        $p = explode(' ', $u);
-        if (count($p) > 1) {
-          // Has trait rep and unit.
-          list($trait_rep, $trait_unit) = $p;
-        }
-        else {
-          if (in_array(trim($u, ';'), $reps)) {
-            // Just the rep no unit.
-            $trait_rep = $u;
-            $trait_unit = '';
-          }
-          else {
-            // Just the unit no trait rep.
-            $trait_rep = '';
-            $trait_unit = $u;
-          }
-        }
-      }
-
-      // When niether is present, use the default value of the trait rep and unit (null).
-      // Trait name without the unit part.
-      $trait_name = preg_replace('/\(.*/', ' ', $header_asset['name']);
-
-      // Add form elements.
-      // Include the project id when modifying a trait header.
-      $default_values = array('count_project'        => $header_asset['count_project'],
-                              'count_data'           => $header_asset['count_data'],
-                              'txt_id'               => $header_asset['cvterm_id'],
-                              'prj_id'               => $header_asset['in_project_id'],
-                              'txt_trait_name'       => trim($trait_name),
-                              'sel_trait_rep'        => trim($trait_rep),
-                              'sel_trait_unit'       => trim($trait_unit),
-                              'txt_trait_definition' => $header_asset['definition'],
-                              'txt_trait_method'     => $header_asset['method'],
-                              'txt_trait_rfriendly'  => $header_asset['r_version'],
-                              'sel_trait_type'       => $header_asset['type'],
-                              'btn_trait_submit'     => 'Save');
-
-      $form = rawpheno_admin_render_form_trait($form, $form_state, $default_values);
-
-      // TABLE
-      // Construct a table, as a summary, showing information about the header.
-
-      $markup = '<h2>SUMMARY: ' . $header_asset['name'] . '</h2> PROJECT: ' . $header_asset['in_project_name'];
-
-      $header_cell = $header_asset['name'] . '<p class="r-ver">' . rawpheno_admin_mark_empty($header_asset['r_version']) . '</p>';
-      $definition_cell = '<p><strong>DEFINITION:</strong><br /> ' . @rawpheno_admin_mark_empty($header_asset['definition']) .  '</p>' .
-                         '<p><strong>COLLECTION METHOD:</strong><br />' . @rawpheno_admin_mark_empty($header_asset['method']) . '</p>';
-
-
-      // Array to hold table properties.
-      $arr_tbl_args = array(
-        'header' => array('-', t('Column Header <small>(unit)</small>'), t('Collection Method'), t('Definition'), t('Type')),
-        'rows' => array(
-          array(1,
-                $header_cell,
-                $header_asset['method'],
-                $header_asset['definition'],
-                strtoupper($header_asset['type'])
-          )
-        ),
-        'sticky' => FALSE,
-        'attributes' => array('id' => 'tbl_header_summary'),
-      );
-
-      // Render the table element.
-      $form['tbl_project_headers'] = array(
-        '#markup' => $markup . theme('table', $arr_tbl_args),
-      );
-
-      return $form;
-    }
-  }
-  elseif ($action == 'delete') {
-    $path = url('../../admin/tripal/extension/rawphenotypes/all_projects/' . $header_asset['in_project_id'] . '/project/manage');
-
-    // Admin wants to delete/remove the trait from the project.
-    db_delete('pheno_project_cvterm')
-      ->condition('cvterm_id', $header_asset['cvterm_id'])
-      ->condition('project_id', $header_asset['in_project_id'])
-      ->execute();
-
-    drupal_goto($path);
   }
 }
 
@@ -1414,6 +1173,190 @@ function rawpheno_admin_project_management_validate($form, &$form_state) {
       }
     }
   }
+}
+
+
+/**
+ * Implements hook_validate().
+ * Ensure that a project is selected when creating a new project.
+ */
+function rawpheno_admin_all_projects_validate($form, &$form_state) {
+  $project_id = $form_state['values']['sel_project'];
+  if ($project_id <= 0) {
+    form_set_error('sel_project', t('No project selected. Please select a project and try again'));
+  }
+
+  $genus = $form_state['values']['sel_genus'];
+  if (empty($genus)) {
+    form_set_error('sel_genus', t('No genus selected. Please select genus and try again'));
+  }
+}
+
+
+/**
+ * Function callback: Validate add existing column headers.
+ */
+function rawpheno_admin_validate_add_existing($form, &$form_state) {
+  if (count(array_filter($form_state['values']['tbl_existing_headers'])) <= 0) {
+    form_set_error('tbl_existing_headers', t('No column headers selected.'));
+  }
+}
+
+
+/**
+ * Function callback: Validate add user.
+ */
+function rawpheno_admin_validate_add_user($form, &$form_state) {
+  $project_id = $form_state['values']['txt_id'];
+  $user = $form_state['values']['txt_autocomplete_user'];
+
+  if (empty($user)) {
+    form_set_error('txt_autocomplete_user', t('No user name supplied in the field.'));
+  }
+  else {
+    // Search user
+    $sql = "SELECT uid FROM {users} WHERE name = :name LIMIT 1";
+    $args = array(':name' => $user);
+    $u = db_query($sql, $args);
+
+    if ($u->rowCount() < 1) {
+      form_set_error('txt_autocomplete_user', t('User does not exist.'));
+    }
+    else {
+      $user_id = $u->fetchObject();
+
+      // Test if user was added twice in the same project.
+      $sql = "SELECT uid FROM pheno_project_user WHERE project_id = :project_id AND uid = :user_id";
+      $args = array(':project_id' => $project_id, ':user_id' => $user_id->uid);
+      $u = db_query($sql, $args);
+
+      if ($u->rowCount() > 0) {
+        form_set_error('txt_autocomplete_user', t('User was already added and cannot be added again'));
+      }
+    }
+  }
+}
+
+
+/**
+ * Function callback: Validate update genus.
+ */
+function rawpheno_admin_validate_update_genus($form, &$form_state) {
+  $genus = $form_state['values']['sel_genus'];
+  if (empty($genus)) {
+    form_set_error('sel_genus', t('No genus selected. Please select genus and try again'));
+  }
+}
+
+
+// SUBMIT.
+
+/**
+ * Implements hook_sumbit().
+ * Create a new project.
+ */
+function rawpheno_admin_all_projects_submit($form, &$form_state) {
+  // When a new project is created, Plant property column headers are
+  // added to a project by default. The following are the plant property headers:
+  // Location, Plot Rep and Entry.
+
+  // Plus and Planting Date and make it essential trait. Planting date is important
+  // as it is used when generating the heatmap.
+  $project_id = $form_state['values']['sel_project'];
+
+  // Get trait types array.
+  $trait_type = rawpheno_function_trait_types();
+
+  // Get Planting Date cvterm id.
+  $planting_date = tripal_get_cvterm(array('name' => 'Planting Date (date)',
+                                     'cv_id' => array('name' => 'phenotype_measurement_types')));
+
+  db_insert('pheno_project_cvterm')
+    ->fields(array(
+      'project_id' => $project_id,
+      'cvterm_id' => $planting_date->cvterm_id,
+      'type' => $trait_type['type1'])
+    )
+  ->execute();
+
+  // Query all plant property types column headers in chado.cvterm table.
+  $sql = "SELECT cvterm_id
+          FROM {cv} AS t1 INNER JOIN {cvterm} AS t2 USING(cv_id)
+          WHERE t1.name = 'phenotype_plant_property_types'
+          ORDER BY cvterm_id ASC";
+
+  $pp = chado_query($sql);
+
+  // Test each plant property if it is present in the project.
+  foreach($pp as $t) {
+    db_insert('pheno_project_cvterm')
+      ->fields(array(
+        'project_id' => $project_id,
+        'cvterm_id' => $t->cvterm_id,
+        'type' => $trait_type['type4'])
+      )
+    ->execute();
+  }
+
+  // Make who created the project as the default user.
+  db_insert('pheno_project_user')
+    ->fields(array(
+      'project_id' => $project_id,
+      'uid' => $GLOBALS['user']->uid)
+    )
+  ->execute();
+
+  if ($GLOBALS['user']->uid != 1) {
+    // If the user is not the superadmin, add as well.
+    db_insert('pheno_project_user')
+      ->fields(array(
+        'project_id' => $project_id,
+        'uid' => 1)
+      )
+    ->execute();
+  }
+
+  // Link genus and project in projectprop.
+  $genus = $form_state['values']['sel_genus'];
+  // Ensure that only the first letter is capitalized.
+  $genus = ucfirst($genus);
+
+  $term = rawpheno_function_organism_cv();
+  // Get cvterm_id of genus term.
+  $genus_cvterm = tripal_get_cvterm($term);
+
+  // Make sure nothing was previously inserted.
+  $project_genus = rawpheno_function_project_organism($project_id);
+
+  if ($project_genus) {
+    // A row found in projectprop.
+    // This project has a genus previously set.
+    // Update that row.
+    db_update('chado.projectprop')
+      ->fields(array(
+        'value' => $genus,
+        )
+      )
+      ->condition('project_id', $project_id, '=')
+      ->condition('type_id', $genus_cvterm->cvterm_id, '=')
+      ->execute();
+  }
+  else {
+    // All Clear. Insert a row.
+    db_insert('chado.projectprop')
+      ->fields(array(
+        'project_id' => $project_id,
+        'type_id' => $genus_cvterm->cvterm_id,
+        'value' => $genus,
+        'rank' => 0,
+        )
+      )
+      ->execute();
+  }
+
+  // Redirect user to project asset management page.
+  $path = url('../../admin/tripal/extension/rawphenotypes/all_projects/' . $project_id . '/project/manage');
+  drupal_goto($path);
 }
 
 
@@ -1596,6 +1539,267 @@ function rawpheno_admin_project_management_submit($form, &$form_state) {
 
       drupal_set_message(t('You have successfully updated a column header in this project.'), 'status');
     }
+  }
+}
+
+
+/**
+ * Function callback: Save values in add existing column headers form.
+ */
+function rawpheno_admin_submit_add_existing($form, &$form_state) {
+  // Uses project id.
+  $project_id = $form_state['values']['txt_id'];
+  // All Types.
+  $types = rawpheno_function_trait_types();
+
+  // The type of header is set to OPTIONAL trait.
+  foreach(array_filter($form_state['values']['tbl_existing_headers']) as $m) {
+    if (isset($form_state['input']['traittype-' . $m]) AND $form_state['input']['traittype-' . $m] == 1) {
+      $trait_type = $types['type1'];
+    }
+    else {
+      $trait_type = $types['type2'];
+    }
+
+    db_insert('pheno_project_cvterm')
+      ->fields(
+        array(
+          'project_id' => $project_id,
+          'cvterm_id' => $m,
+          'type' => $trait_type)
+      )
+      ->execute();
+  }
+
+  drupal_set_message(t('You have successfully added column headers to this project.'), 'status');
+}
+
+
+/**
+ * Function callback: Save values in add user form.
+ */
+function rawpheno_admin_submit_add_user($form, $form_state) {
+  // Uses project id
+  $project_id = $form_state['values']['txt_id'];
+  $user = $form_state['values']['txt_autocomplete_user'];
+
+  // Search user
+  $sql = "SELECT uid FROM {users}
+          WHERE
+            name = :name
+            AND uid NOT IN (SELECT uid FROM {pheno_project_user} WHERE project_id = :project_id AND status = 1)
+          LIMIT 1";
+
+  $args = array(':name' => $user, ':project_id' => $project_id);
+  $u = db_query($sql, $args)
+    ->fetchField();
+
+  db_insert('pheno_project_user')
+    ->fields(array(
+      'project_id' => $project_id,
+      'uid' => $u))
+    ->execute();
+
+  drupal_set_message(t('You have successfully added users to this project.'), 'status');
+}
+
+
+/**
+ * Function callback: Update project genus.
+ */
+function rawpheno_admin_submit_update_genus($form, $form_state) {
+  $project_id = $form['#project_id'];
+
+  // Form field values.
+  $genus = $form_state['values']['sel_genus'];
+  // Ensure that only the first letter is capitalized.
+  $genus = ucfirst($genus);
+
+  // Update that row.
+  $term = rawpheno_function_organism_cv();
+  // Get cvterm_id of genus term.
+  $genus_cvterm = tripal_get_cvterm($term);
+
+  // Make sure nothing was previously inserted.
+  $project_genus = rawpheno_function_project_organism($project_id);
+
+  if ($project_genus) {
+    // A row found in projectprop.
+    // This project has a genus previously set.
+    // Update that row.
+
+    // Final check before updating. Should have no data.
+    $project_has_data = rawpheno_function_data($project_id);
+
+    if (!$project_has_data) {
+      db_update('chado.projectprop')
+        ->fields(array(
+          'value' => $genus
+          )
+        )
+        ->condition('project_id', $project_id, '=')
+        ->condition('type_id', $genus_cvterm->cvterm_id, '=')
+        ->execute();
+    }
+  }
+  else {
+    // All Clear. Insert a row.
+    db_insert('chado.projectprop')
+      ->fields(array(
+        'project_id' => $project_id,
+        'type_id' => $genus_cvterm->cvterm_id,
+        'value' => $genus,
+        'rank' => 0,
+        )
+      )
+      ->execute();
+  }
+}
+
+
+// HELPER FUNCTION.
+
+/**
+ * Function callback: Construct form to edit column header and handle deletion.
+ *
+ * @param $header_asset
+ *   An array containing information about a column header.
+ * @param $action
+ *   A string containing the process to be carried out to a header.
+ */
+function rawpheno_admin_project_headers($form, $form_state, $header_asset, $action) {
+  $breadcrumbs = array();
+  $breadcrumbs[] = l('Home', '');
+  $breadcrumbs[] = l('Rawphenotypes', '/admin/tripal/extension/rawphenotypes');
+  $breadcrumbs[] = l('Manage Projects', '/admin/tripal/extension/rawphenotypes/all_projects');
+
+  drupal_set_breadcrumb($breadcrumbs);
+
+  // Set the title of this page. This line will create a page title on upper left hand
+  // corner of the page preceding the tabs.
+  drupal_set_title('Manage Project Assets / Update Header');
+
+  if ($action == 'edit') {
+    if ($header_asset['name'] == 'Lodging (Scale: 1-5) upright - lodged' OR $header_asset['name'] == 'Comments') {
+      // Is lodging header.
+      $goback = '&nbsp;<a href="javascript:history.back();">Go back</a>';
+      drupal_set_message(t('Cannot edit @name.', array('@name' => $header_asset['name'])) . $goback, 'error');
+    }
+    else {
+      // Other headers.
+      // CONSTRUCT EDIT FORM.
+
+      // FORM
+      // Add a link to allow administrator to go back to the list of traits in a project.
+      $form['back_link'] = array(
+        '#type' => 'markup',
+        '#markup' => l('Go back to projects table', 'admin/tripal/extension/rawphenotypes/all_projects') . ' | ' . l(t('Go back to project column headers table') ,'admin/tripal/extension/rawphenotypes/all_projects/' . $header_asset['in_project_id'] . '/project/manage'),
+      );
+
+      $form['fieldset_trait'] = array(
+        '#type' => 'fieldset',
+        '#title' => t('Eidt Column Header:'),
+        '#collapsed' => FALSE,
+        '#collapsible' => TRUE,
+      );
+
+      // Trait name field.
+      // Extract the trait rep value, trait unit and the trait name.
+      // NOTE: this can only process header following the format: trait name (trait rep; unit)
+      $trait_rep = $trait_unit = '';
+      // Extract the text value inside the parenthesis (unit part).
+      $t = preg_match("/.*\(([^)]*)\)/", $header_asset['name'], $match);
+      $u = (isset($match[1])) ? $match[1] : '';
+
+      // Extract information in a unit only when there is a unit in the first place.
+      // Get the Trait rep (eg R1, R7, 1st) and measurement unit (eg cm, days) values.
+      $reps = rawpheno_function_trait_reps();
+
+      if ($t) {
+        // Split the information and see if either trait rep or unit is present.
+        $p = explode(' ', $u);
+        if (count($p) > 1) {
+          // Has trait rep and unit.
+          list($trait_rep, $trait_unit) = $p;
+        }
+        else {
+          if (in_array(trim($u, ';'), $reps)) {
+            // Just the rep no unit.
+            $trait_rep = $u;
+            $trait_unit = '';
+          }
+          else {
+            // Just the unit no trait rep.
+            $trait_rep = '';
+            $trait_unit = $u;
+          }
+        }
+      }
+
+      // When niether is present, use the default value of the trait rep and unit (null).
+      // Trait name without the unit part.
+      $trait_name = preg_replace('/\(.*/', ' ', $header_asset['name']);
+
+      // Add form elements.
+      // Include the project id when modifying a trait header.
+      $default_values = array('count_project'        => $header_asset['count_project'],
+                              'count_data'           => $header_asset['count_data'],
+                              'txt_id'               => $header_asset['cvterm_id'],
+                              'prj_id'               => $header_asset['in_project_id'],
+                              'txt_trait_name'       => trim($trait_name),
+                              'sel_trait_rep'        => trim($trait_rep),
+                              'sel_trait_unit'       => trim($trait_unit),
+                              'txt_trait_definition' => $header_asset['definition'],
+                              'txt_trait_method'     => $header_asset['method'],
+                              'txt_trait_rfriendly'  => $header_asset['r_version'],
+                              'sel_trait_type'       => $header_asset['type'],
+                              'btn_trait_submit'     => 'Save');
+
+      $form = rawpheno_admin_render_form_trait($form, $form_state, $default_values);
+
+      // TABLE
+      // Construct a table, as a summary, showing information about the header.
+
+      $markup = '<h2>SUMMARY: ' . $header_asset['name'] . '</h2> PROJECT: ' . $header_asset['in_project_name'];
+
+      $header_cell = $header_asset['name'] . '<p class="r-ver">' . rawpheno_admin_mark_empty($header_asset['r_version']) . '</p>';
+      $definition_cell = '<p><strong>DEFINITION:</strong><br /> ' . @rawpheno_admin_mark_empty($header_asset['definition']) .  '</p>' .
+                         '<p><strong>COLLECTION METHOD:</strong><br />' . @rawpheno_admin_mark_empty($header_asset['method']) . '</p>';
+
+
+      // Array to hold table properties.
+      $arr_tbl_args = array(
+        'header' => array('-', t('Column Header <small>(unit)</small>'), t('Collection Method'), t('Definition'), t('Type')),
+        'rows' => array(
+          array(1,
+                $header_cell,
+                $header_asset['method'],
+                $header_asset['definition'],
+                strtoupper($header_asset['type'])
+          )
+        ),
+        'sticky' => FALSE,
+        'attributes' => array('id' => 'tbl_header_summary'),
+      );
+
+      // Render the table element.
+      $form['tbl_project_headers'] = array(
+        '#markup' => $markup . theme('table', $arr_tbl_args),
+      );
+
+      return $form;
+    }
+  }
+  elseif ($action == 'delete') {
+    $path = url('../../admin/tripal/extension/rawphenotypes/all_projects/' . $header_asset['in_project_id'] . '/project/manage');
+
+    // Admin wants to delete/remove the trait from the project.
+    db_delete('pheno_project_cvterm')
+      ->condition('cvterm_id', $header_asset['cvterm_id'])
+      ->condition('project_id', $header_asset['in_project_id'])
+      ->execute();
+
+    drupal_goto($path);
   }
 }
 
@@ -1817,112 +2021,6 @@ function rawpheno_admin_construct_trait_name($trait) {
 
 
 /**
- * Function callback: Save values in add existing column headers form.
- */
-function rawpheno_admin_submit_add_existing($form, &$form_state) {
-  // Uses project id.
-  $project_id = $form_state['values']['txt_id'];
-  // All Types.
-  $types = rawpheno_function_trait_types();
-
-  // The type of header is set to OPTIONAL trait.
-  foreach(array_filter($form_state['values']['tbl_existing_headers']) as $m) {
-    if (isset($form_state['input']['traittype-' . $m]) AND $form_state['input']['traittype-' . $m] == 1) {
-      $trait_type = $types['type1'];
-    }
-    else {
-      $trait_type = $types['type2'];
-    }
-
-    db_insert('pheno_project_cvterm')
-      ->fields(
-        array(
-          'project_id' => $project_id,
-          'cvterm_id' => $m,
-          'type' => $trait_type)
-      )
-      ->execute();
-  }
-
-  drupal_set_message(t('You have successfully added column headers to this project.'), 'status');
-}
-
-
-/**
- * Function callback: Validate add existing column headers.
- */
-function rawpheno_admin_validate_add_existing($form, &$form_state) {
-  if (count(array_filter($form_state['values']['tbl_existing_headers'])) <= 0) {
-    form_set_error('tbl_existing_headers', t('No column headers selected.'));
-  }
-}
-
-
-/**
- * Function callback: Save values in add user form.
- */
-function rawpheno_admin_submit_add_user($form, $form_state) {
-  // Uses project id
-  $project_id = $form_state['values']['txt_id'];
-  $user = $form_state['values']['txt_autocomplete_user'];
-
-  // Search user
-  $sql = "SELECT uid FROM {users}
-          WHERE
-            name = :name
-            AND uid NOT IN (SELECT uid FROM {pheno_project_user} WHERE project_id = :project_id AND status = 1)
-          LIMIT 1";
-
-  $args = array(':name' => $user, ':project_id' => $project_id);
-  $u = db_query($sql, $args)
-    ->fetchField();
-
-  db_insert('pheno_project_user')
-    ->fields(array(
-      'project_id' => $project_id,
-      'uid' => $u))
-    ->execute();
-
-  drupal_set_message(t('You have successfully added users to this project.'), 'status');
-}
-
-
-/**
- * Function callback: Validate add user.
- */
-function rawpheno_admin_validate_add_user($form, &$form_state) {
-  $project_id = $form_state['values']['txt_id'];
-  $user = $form_state['values']['txt_autocomplete_user'];
-
-  if (empty($user)) {
-    form_set_error('txt_autocomplete_user', t('No user name supplied in the field.'));
-  }
-  else {
-    // Search user
-    $sql = "SELECT uid FROM {users} WHERE name = :name LIMIT 1";
-    $args = array(':name' => $user);
-    $u = db_query($sql, $args);
-
-    if ($u->rowCount() < 1) {
-      form_set_error('txt_autocomplete_user', t('User does not exist.'));
-    }
-    else {
-      $user_id = $u->fetchObject();
-
-      // Test if user was added twice in the same project.
-      $sql = "SELECT uid FROM pheno_project_user WHERE project_id = :project_id AND uid = :user_id";
-      $args = array(':project_id' => $project_id, ':user_id' => $user_id->uid);
-      $u = db_query($sql, $args);
-
-      if ($u->rowCount() > 0) {
-        form_set_error('txt_autocomplete_user', t('User was already added and cannot be added again'));
-      }
-    }
-  }
-}
-
-
-/**
  * Function get properties of project the user is assigned.
  *
  * @param $asset_id
@@ -1968,71 +2066,8 @@ function rawpheno_admin_user_assets($asset_id) {
 
 
 /**
- * Function callback: Update project genus.
+ * Function to replace blank spaces to - character.
  */
-function rawpheno_admin_submit_update_genus($form, $form_state) {
-  $project_id = $form['#project_id'];
-
-  // Form field values.
-  $genus = $form_state['values']['sel_genus'];
-  // Ensure that only the first letter is capitalized.
-  $genus = ucfirst($genus);
-
-  // Get genus/organism controlled vocabulary term.
-  // Term.
-  $term = rawpheno_function_organism_cv();
-  $genus_cvterm = tripal_get_cvterm($term);
-
-  // Locate project in projectprop.
-  $sql = "SELECT projectprop_id FROM {projectprop} WHERE project_id = :project_id AND type_id = :organism_cvterm_id";
-  $args = array(':project_id' => $project_id, ':organism_cvterm_id' => $genus_cvterm->cvterm_id);
-
-  $g = chado_query($sql, $args);
-
-  if ($g->rowCount() > 0) {
-    // No record found.
-    // Update is an insert row command.
-    // Final check before updating. Should have no data.
-    $project_has_data = rawpheno_function_data($project_id);
-
-    if (!$project_has_data) {
-      db_update('chado.projectprop')
-        ->fields(array(
-          'value' => $genus
-          )
-        )
-        ->condition('project_id', $project_id, '=')
-        ->condition('type_id', $genus_cvterm->cvterm_id, '=')
-        ->execute();
-    }
-  }
-  else {
-    // Appears the project has an entry in the projectprop table.
-    // Update is an update row command.
-    db_insert('chado.projectprop')
-      ->fields(array(
-        'project_id' => $project_id,
-        'type_id' => $genus_cvterm->cvterm_id,
-        'value' => $genus,
-        'rank' => 0,
-        )
-      )
-      ->execute();
-  }
-}
-
-
-/**
- * Function callback: Validate update genus.
- */
-function rawpheno_admin_validate_update_genus($form, &$form_state) {
-  $genus = $form_state['values']['sel_genus'];
-  if (empty($genus)) {
-    form_set_error('sel_organism', t('No genus selected. Please select genus and try again'));
-  }
-}
-
-
 function rawpheno_admin_mark_empty($val) {
   return (empty($val)) ? '-' : $val;
 }

--- a/include/rawpheno.admin.form.inc
+++ b/include/rawpheno.admin.form.inc
@@ -688,10 +688,76 @@ function rawpheno_admin_project($form, &$form_state, $project_id) {
   $project = chado_generate_var('project', array('project_id' => $project_id));
   $markup .= '<h2>PROJECT: ' . $project->name . '</h2>';
 
+  // Fetch the genus of this project.
+  $project_genus = rawpheno_function_project_organism($project_id);
+
+  // When project has no genus set, warn admin.
+  if (!$project_genus) {
+    $project_genus = '---';
+    $warning = '&nbsp;&nbsp;<img src="../../../../../../../misc/message-16-warning.png" title="Project genus not set." alt="Project genus not set." /> Not set';
+  }
+  else {
+    $warning = '';
+  }
+
+  $markup .= '<div class="tag-name">GENUS: ' . $project_genus . '</div>' . $warning;
+
   $form['project_info'] = array(
     '#type' => 'markup',
     '#markup' => $markup,
   );
+
+  // Check if project has data and so, do not allow admin to change genus.
+  // Otherwise, it's safe, allow admin to change.
+  $project_has_data = rawpheno_function_data($project_id);
+
+  if ($project_genus == '---' || !$project_has_data) {
+    // Fetch genus.
+    // NOTE: saving genus instead of the organism.
+    $sql = "SELECT genus, UPPER(genus) FROM {organism} GROUP BY genus ORDER BY genus";
+    $g = chado_query($sql);
+
+    if ($g->rowCount() > 0) {
+      $genus = $g->fetchAllKeyed();
+      // When project has organism set, remove it from options.
+      if ($project_genus) {
+        unset($genus[$project_genus]);
+      }
+
+      $options = array('' => '---') + $genus;
+
+      // Not set, show the form.
+      $collapse = (!$project_genus) ? FALSE : TRUE;
+
+      $form['fieldset_update_genus'] = array(
+        '#type' => 'fieldset',
+        '#title' => t('Update Genus'),
+        '#collapsed' => $collapse,
+        '#collapsible' => TRUE,
+      );
+
+      // List genus - select box to select genus the project is collecting data for/to.
+      $form['fieldset_update_genus']['sel_genus'] = array(
+        '#type' => 'select',
+        '#title' => t('Project is collecting data for genus:'),
+        '#options' => $options,
+        '#default_value' => array_keys($options)[0],
+        '#id' => 'admin-sel-genus'
+      );
+
+      $form['fieldset_update_genus']['save_genus'] = array(
+        '#type' => 'submit',
+        '#value' => t('Update genus'),
+        '#validate' => array('rawpheno_admin_validate_update_genus'),
+        '#submit' => array('rawpheno_admin_submit_update_genus'),
+        '#limit_validation_errors' => array(
+          array('sel_genus')
+        )
+      );
+
+      $form['#project_id']  = $project_id;
+    }
+  }
 
   // Arguments to all SQL queries below.
   $args = array(':project_id' => $project_id);
@@ -1898,6 +1964,72 @@ function rawpheno_admin_user_assets($asset_id) {
   $arr_project_assets['project_data_count'] = $data_count;
 
   return $arr_project_assets;
+}
+
+
+/**
+ * Function callback: Update project genus.
+ */
+function rawpheno_admin_submit_update_genus($form, $form_state) {
+  $project_id = $form['#project_id'];
+
+  // Form field values.
+  $genus = $form_state['values']['sel_genus'];
+  // Ensure that only the first letter is capitalized.
+  $genus = ucfirst($genus);
+
+  // Get genus/organism controlled vocabulary term.
+  // Term.
+  $term = rawpheno_function_organism_cv();
+  $genus_cvterm = tripal_get_cvterm($term);
+
+  // Locate project in projectprop.
+  $sql = "SELECT projectprop_id FROM {projectprop} WHERE project_id = :project_id AND type_id = :organism_cvterm_id";
+  $args = array(':project_id' => $project_id, ':organism_cvterm_id' => $genus_cvterm->cvterm_id);
+
+  $g = chado_query($sql, $args);
+
+  if ($g->rowCount() > 0) {
+    // No record found.
+    // Update is an insert row command.
+    // Final check before updating. Should have no data.
+    $project_has_data = rawpheno_function_data($project_id);
+
+    if (!$project_has_data) {
+      db_update('chado.projectprop')
+        ->fields(array(
+          'value' => $genus
+          )
+        )
+        ->condition('project_id', $project_id, '=')
+        ->condition('type_id', $genus_cvterm->cvterm_id, '=')
+        ->execute();
+    }
+  }
+  else {
+    // Appears the project has an entry in the projectprop table.
+    // Update is an update row command.
+    db_insert('chado.projectprop')
+      ->fields(array(
+        'project_id' => $project_id,
+        'type_id' => $genus_cvterm->cvterm_id,
+        'value' => $genus,
+        'rank' => 0,
+        )
+      )
+      ->execute();
+  }
+}
+
+
+/**
+ * Function callback: Validate update genus.
+ */
+function rawpheno_admin_validate_update_genus($form, &$form_state) {
+  $genus = $form_state['values']['sel_genus'];
+  if (empty($genus)) {
+    form_set_error('sel_organism', t('No genus selected. Please select genus and try again'));
+  }
 }
 
 

--- a/include/rawpheno.function.measurements.inc
+++ b/include/rawpheno.function.measurements.inc
@@ -212,6 +212,17 @@ function rawpheno_function_trait_reps() {
 
 
 /**
+ * Function return genus controlled vocabulary.
+ */
+function rawpheno_function_organism_cv() {
+  return array(
+    'name' => 'genus',
+    'cv_id' => array('name' => 'taxonomic_rank')
+  );
+}
+
+
+/**
  * Function that list default/initial units available to this module.
  *
  * @param $set
@@ -253,11 +264,23 @@ function rawpheno_function_project() {
  * Function to test if the module has a project set up for user and
  * that project has dataset associated to it.
  *
+ * @param $project_id
+ *  An integer containing the project id, when supplied test the to see if that
+ *  project has data associated to it.
+ *
  * @return FALSE when there is no data.
  */
-function rawpheno_function_data() {
-  $sql = "SELECT plant_project_id FROM pheno_plant_project";
-  $stock_count = db_query($sql)
+function rawpheno_function_data($project_id = NULL) {
+  if ($project_id) {
+    $sql = "SELECT plant_project_id FROM pheno_plant_project WHERE project_id = :project_id";
+    $args = array(':project_id' => $project_id);
+  }
+  else {
+    $sql = "SELECT plant_project_id FROM pheno_plant_project";
+    $args = array();
+  }
+
+  $stock_count = db_query($sql, $args)
     ->rowCount();
 
   return ($stock_count <= 0) ? 0 : 1;
@@ -1172,3 +1195,63 @@ function rawpheno_function_plot_exists($plot, $project_id) {
 
   return $m->fetchField(0);
 }
+
+
+/**
+ * Function to fetch the organism the project is collecting data for/to.
+ *
+ * @param $project_id
+ *   An integer containing the project id number.
+ *
+ * @param $dataset
+ *   String (full) to indicate function will return project organism and organism id array.
+ *
+ * @return string and array of integer (id number of organism).
+ *   The genus/organism name and organism id number.
+ */
+function rawpheno_function_project_organism($project_id, $dataset = NULL) {
+  // Get genus cvterm.
+  $term = rawpheno_function_organism_cv();
+  // Get cvterm_id of genus term.
+  $genus_cvterm = tripal_get_cvterm($term);
+  // Project genus/organism string value;
+  $project_genus = '';
+  // Array to hold project genus organism information.
+  $arr_project_genus_organism = array();
+
+  // Get the organism the project is collecting data for/to.
+  $sql = "SELECT organism_id, genus, common_name FROM {organism}
+  WHERE genus = (SELECT TRIM(value) FROM {projectprop} WHERE project_id = :project_id AND type_id = :genus_cvterm_id LIMIT 1)";
+
+  $args = array(':project_id' => $project_id, ':genus_cvterm_id' => $genus_cvterm->cvterm_id);
+  $p = chado_query($sql, $args);
+
+  if ($p->rowCount() > 0) {
+    foreach($p as $i => $o) {
+      // Extract the genus from the result set.
+      if ($i == 0) {
+        $project_genus = $o->genus;
+
+        // Wants the genus only.
+        if (!$dataset) {
+          return $project_genus;
+        }
+      }
+
+      // Save the organisms.
+      // This list will be used to limit the stock when validating a spreadsheet.
+      $arr_project_genus_organism[$o->organism_id] = $o->common_name;
+    }
+
+    // Full info. genus + organisms.
+    return array(
+      'genus' => $project_genus,
+      'organism' => $arr_project_genus_organism,
+    );
+  }
+  else {
+    // Not set, as for previous releases, warn the admin about this.
+    return 0;
+  }
+}
+

--- a/include/rawpheno.upload.excel.inc
+++ b/include/rawpheno.upload.excel.inc
@@ -515,6 +515,10 @@ function rawpheno_validate_excel_file($file, $project_id, $source) {
   // Change to the correct spreadsheet.
   rawpheno_change_sheet($xls_obj, 'measurements');
 
+  // Limit the stocks for comparison/validation to just the organism that matched the project genus.
+  $project_prop = rawpheno_function_project_organism($project_id, 'full');
+  $project_genus_organism_ids = array_keys($project_prop['organism']);
+
   // This increment variable $i is required since xls and xlsx
   // parsers assign array index differently.
   // XLS starts at 1, while XLSX at 0;
@@ -616,7 +620,7 @@ function rawpheno_validate_excel_file($file, $project_id, $source) {
                     $context['plot_req'] = $plot_req;
                   }
 
-                  $result = $validator['validation callback']($cell, $context, $tmp_storage);
+                  $result = $validator['validation callback']($cell, $context, $tmp_storage, $project_genus_organism_ids);
 
                   // Note: we use tmp storage b/c passing $storage[$validator_name] directly
                   // doesn't seem to work.

--- a/include/rawpheno.upload.excel.inc
+++ b/include/rawpheno.upload.excel.inc
@@ -82,6 +82,10 @@ function rawpheno_load_spreadsheet($project_id, $arr_newheaders, $fid, $plantpro
     // print "\nNow parsing each row and saving it to the database...\nNumber of rows saved: \n";
     $i = 0;
 
+    // Limit the stocks for comparison/validation to just the organism that matched the project genus.
+    $project_prop = rawpheno_function_project_organism($project_id, 'full');
+    $project_genus_organism_ids = array_keys($project_prop['organism']);
+
     // Each row in the spreadsheet.
     foreach ($xls_obj as $row) {
       // Create progress update by computing the number of rows saved in percent.
@@ -131,8 +135,15 @@ function rawpheno_load_spreadsheet($project_id, $arr_newheaders, $fid, $plantpro
       // Process the name column first since we need a plant_id before we can insert any more data.
       // Name column header goes into pheno_plant.
       // Check if stock name exists.
+
+      // Limit the name search to just stocks in project organism.
       $stock_id = NULL;
-      $r = chado_query('SELECT stock_id FROM {stock} WHERE name=:name', array(':name' => trim($row[$name_index])));
+
+      // Limit the stocks for comparison/validation to just the organism defined in the project.
+      $sql = "SELECT stock_id FROM {stock} WHERE name = :name AND organism_id IN (:project_organism_ids)";
+      $args = array(':name' => trim($row[$name_index]), ':project_organism_ids' => $project_genus_organism_ids);
+
+      $r = chado_query($sql, $args);
       if ($r) $stock_id = $r->fetchField();
 
       // Determine if name has a stock id number.

--- a/include/rawpheno.validation.inc
+++ b/include/rawpheno.validation.inc
@@ -639,14 +639,19 @@ function validator_germplasm_present_generate_msg($error_info) {
  *   0 = no matching stock.
  *   9 = too many matching stocks (not unique).
  */
-function validator_germplasm_present_validate_cell($value, $context, &$storage) {
+function validator_germplasm_present_validate_cell($value, $context, &$storage, $project_genus_organism_ids) {
 
   // We don't want this test to catch empty cells. There is a separate test for testing required values are resent.
   if (empty($value)) {
     return TRUE;
   }
 
-  $stocks = chado_query('SELECT stock_id FROM {stock} WHERE name=:name', array(':name' => $value))->fetchAll();
+  // Limit the stocks for comparison/validation to just the organism defined in the project.
+  $sql = "SELECT stock_id FROM {stock} WHERE name = :name AND organism_id IN (:project_organism_ids)";
+  $args = array(':name' => $value, ':project_organism_ids' => $project_genus_organism_ids);
+
+  $stocks = chado_query($sql, $args)
+    ->fetchAll();
 
   if (sizeof($stocks) == 1) {
     return TRUE;

--- a/rawpheno.install
+++ b/rawpheno.install
@@ -298,6 +298,10 @@ function rawpheno_function_terms($type) {
       return 'AGILE: Application of Genomic Innovation in the Lentil Economy';
       break;
 
+    case 'project_genus':
+      return 'Lens';
+      break;
+
     case 'defaults':
       // Default colour scheme and heading/title.
       return array('colour' => '#304356',
@@ -427,6 +431,47 @@ function rawpheno_install() {
                        'uid' => 1))
         ->execute();
       }
+
+    // Tell the module that AGILE is collecting data for project genus.
+    // NOTE: Code block in hook_update().
+    // This project - genus.
+    $project_genus = rawpheno_function_terms('project_genus');
+    // Ensure only first letter is capitalized.
+    $project_genus = ucfirst($project_genus);
+    // Get genus/organism controlled vocabulary term.
+    // Term.
+    $term = rawpheno_function_organism_cv();
+    $genus_cvterm = tripal_get_cvterm($term);
+
+    // Make sure nothing was previously inserted.
+    $sql = "SELECT projectprop_id FROM {projectprop}
+            WHERE project_id = :project_id AND type_id = :organism_cvterm_id";
+
+    $args = array(':project_id' => $project_ID, ':organism_cvterm_id' => $genus_cvterm->cvterm_id);
+    $o = chado_query($sql, $args);
+
+    if ($o->rowCount() > 0) {
+      // Update.
+      db_update('chado.projectprop')
+        ->fields(array(
+          'value' => $project_genus,
+          )
+        )
+        ->condition('project_id', $project_ID, '=')
+        ->condition('type_id', $genus_cvterm->cvterm_id, '=')
+        ->execute();
+    }
+    else {
+      // All clear...
+      chado_insert_record('projectprop',
+        array(
+          'project_id' => $project_ID,
+          'type_id' => $genus_cvterm->cvterm_id,
+          'value' => $project_genus,
+          'rank' => 0,
+        )
+      );
+    }
   }
 
   // Initialize R Transformation rules required in generating R version of header.
@@ -687,6 +732,8 @@ function rawpheno_uninstall() {
     $del = "DELETE FROM {cv} WHERE cv_id = :cv_id";
     chado_query($del, $args);
   }
+
+  // Do not delete rows in projectprop.
 }
 
 

--- a/rawpheno.install
+++ b/rawpheno.install
@@ -430,31 +430,25 @@ function rawpheno_install() {
         ->fields(array('project_id' => $project_ID,
                        'uid' => 1))
         ->execute();
-      }
+    }
 
-    // Tell the module that AGILE is collecting data for project genus.
-    // NOTE: Code block in hook_update().
+    // Tell the module that AGILE is collecting data for project organism.
     // This project - genus.
     $project_genus = rawpheno_function_terms('project_genus');
-    // Ensure only first letter is capitalized.
-    $project_genus = ucfirst($project_genus);
     // Get genus/organism controlled vocabulary term.
     // Term.
     $term = rawpheno_function_organism_cv();
+    // Get cvterm_id of genus term.
     $genus_cvterm = tripal_get_cvterm($term);
 
     // Make sure nothing was previously inserted.
-    $sql = "SELECT projectprop_id FROM {projectprop}
-            WHERE project_id = :project_id AND type_id = :organism_cvterm_id";
+    $projectprop_genus = rawpheno_function_project_organism($project_ID);
 
-    $args = array(':project_id' => $project_ID, ':organism_cvterm_id' => $genus_cvterm->cvterm_id);
-    $o = chado_query($sql, $args);
-
-    if ($o->rowCount() > 0) {
-      // Update.
+    if ($projectprop_genus) {
+      // Found a row.
       db_update('chado.projectprop')
         ->fields(array(
-          'value' => $project_genus,
+          'value' => $project_genus
           )
         )
         ->condition('project_id', $project_ID, '=')
@@ -462,15 +456,16 @@ function rawpheno_install() {
         ->execute();
     }
     else {
-      // All clear...
-      chado_insert_record('projectprop',
-        array(
+      // Clear, insert a row.
+      db_insert('chado.projectprop')
+        ->fields(array(
           'project_id' => $project_ID,
           'type_id' => $genus_cvterm->cvterm_id,
           'value' => $project_genus,
           'rank' => 0,
+          )
         )
-      );
+        ->execute();
     }
   }
 
@@ -916,6 +911,42 @@ function rawpheno_update_7002() {
     );
 
     $project_ID = $tmp->project_id;
+
+    // Tell the module that AGILE is collecting data for project organism.
+    // This project - genus.
+    $project_genus = rawpheno_function_terms('project_genus');
+    // Get genus/organism controlled vocabulary term.
+    // Term.
+    $term = rawpheno_function_organism_cv();
+    // Get cvterm_id of genus term.
+    $genus_cvterm = tripal_get_cvterm($term);
+
+    // Make sure nothing was previously inserted.
+    $projectprop_genus = rawpheno_function_project_organism($project_ID);
+
+    if ($projectprop_genus) {
+      // Found a row.
+      db_update('chado.projectprop')
+        ->fields(array(
+          'value' => $project_genus
+          )
+        )
+        ->condition('project_id', $project_ID, '=')
+        ->condition('type_id', $genus_cvterm->cvterm_id, '=')
+        ->execute();
+    }
+    else {
+      // Clear, insert a row.
+      db_insert('chado.projectprop')
+        ->fields(array(
+          'project_id' => $project_ID,
+          'type_id' => $genus_cvterm->cvterm_id,
+          'value' => $project_genus,
+          'rank' => 0,
+          )
+        )
+        ->execute();
+    }
   }
 
   // Trait types array.

--- a/rawpheno.module
+++ b/rawpheno.module
@@ -258,7 +258,7 @@ function rawpheno_permission() {
 function rawpheno_preprocess_rawpheno_rawdata(&$variables, $hook) {
   // Colour scheme, project check and data check.
   $rawpheno_load = rawpheno_module_defaults();
-  list($variables['theme_colour'], $variables['my_projects'], $variables['has_prj'], $variables['has_data']) = $rawpheno_load;
+  list($variables['theme_colour'], $variables['my_projects'], $variables['has_prj'], $variables['has_data'], $variables['has_genus']) = $rawpheno_load;
 
   // Cross-link rawdata page to download page.
   $variables['rel_url'] = url('phenotypes/raw/download');

--- a/rawpheno.module
+++ b/rawpheno.module
@@ -283,7 +283,7 @@ function rawpheno_preprocess_rawpheno_rawdata(&$variables, $hook) {
 function rawpheno_preprocess_rawpheno_instructions(&$variables, $hook) {
   // Colour scheme, project check and data check.
   $rawpheno_load = rawpheno_module_defaults();
-  list($variables['theme_colour'], $variables['my_projects'], $variables['has_prj'], $variables['has_data']) = $rawpheno_load;
+  list($variables['theme_colour'], $variables['my_projects'], $variables['has_prj'], $variables['has_data'], $variables['has_genus']) = $rawpheno_load;
 
   // Cross-link instructions page to upload page.
   $variables['rel_url'] = url('phenotypes/raw/upload');
@@ -305,7 +305,7 @@ function rawpheno_preprocess_rawpheno_instructions(&$variables, $hook) {
 function rawpheno_preprocess_rawpheno_upload_form_master(&$variables, $hook) {
   // Colour scheme, project check and data check.
   $rawpheno_load = rawpheno_module_defaults();
-  list($variables['theme_colour'], $variables['my_projects'], $variables['has_prj'], $variables['has_data']) = $rawpheno_load;
+  list($variables['theme_colour'], $variables['my_projects'], $variables['has_prj'], $variables['has_data'], $variables['has_genus']) = $rawpheno_load;
 
   // Directory permission used in upload and backup.
   $pub_dir = 'public://';
@@ -349,7 +349,7 @@ function rawpheno_preprocess_rawpheno_upload_form_master(&$variables, $hook) {
 function rawpheno_preprocess_rawpheno_backup(&$variables, $hook) {
   // Colour scheme, project check and data check.
   $rawpheno_load = rawpheno_module_defaults();
-  list($variables['theme_colour'], $variables['my_projects'], $variables['has_prj'], $variables['has_data']) = $rawpheno_load;
+  list($variables['theme_colour'], $variables['my_projects'], $variables['has_prj'], $variables['has_data'], $variables['has_genus']) = $rawpheno_load;
 
   // Directory permission used in upload and backup.
   $pub_dir = 'public://';
@@ -378,7 +378,7 @@ function rawpheno_preprocess_rawpheno_backup(&$variables, $hook) {
 function rawpheno_preprocess_rawpheno_download(&$variables, $hook) {
   // Colour scheme, project check and data check.
   $rawpheno_load = rawpheno_module_defaults();
-  list($variables['theme_colour'], $variables['my_projects'], $variables['has_prj'], $variables['has_data']) = $rawpheno_load;
+  list($variables['theme_colour'], $variables['my_projects'], $variables['has_prj'], $variables['has_data'], $variables['has_genus']) = $rawpheno_load;
 
   // Cross-link download page to download page.
   $variables['rel_url'] = url('phenotypes/raw');
@@ -404,6 +404,21 @@ function rawpheno_module_defaults() {
   $log_user = $GLOBALS['user']->uid;
   $my_projects = rawpheno_function_user_project($log_user);
 
+  // If project has genus defined.
+  $my_project_ids = array_keys($my_projects);
+  $my_project_genus = array();
+
+  foreach($my_project_ids as $p_id) {
+    $genus = rawpheno_function_project_organism($p_id);
+
+    if ($genus) {
+      $my_project_genus[] = $genus;
+    }
+  }
+
+  // Each project must have a genus, see that is true.
+  $has_genus = (count($my_project_ids) == count($my_project_genus)) ? 1 : 0;
+
   // Does the module contain project?
   $has_project = rawpheno_function_project();
 
@@ -415,6 +430,7 @@ function rawpheno_module_defaults() {
     $my_projects, // User appointed project.
     $has_project, // Module has at least a project.
     $has_data,    // Module has data.
+    $has_genus,   // All project assigned to user should have genus defined.
   );
 }
 

--- a/theme/css/rawpheno.admin.style.css
+++ b/theme/css/rawpheno.admin.style.css
@@ -296,3 +296,24 @@ div.container-cell p:last-child {
   -moz-border-radius: 10px;
   border-radius: 10px;
 }
+
+.more-info {
+  cursor: pointer;
+}
+
+/* Mouse hover show more info */
+.hover-more-info {
+  background-color: rgba(248, 240, 177, 0.9);
+  border: 2px solid #CBCf54;
+
+  color: black;
+  display: none;
+  font-size: 1em;
+  font-style: italic;
+  padding: 10px;
+  position: absolute;
+
+   -webkit-box-shadow: 0px 2px 10px 3px rgba(0, 0, 0, 0.2);
+  -moz-box-shadow: 0px 2px 10px 3px rgba(0, 0, 0, 0.2);
+  box-shadow: 0px 2px 10px 3px rgba(0, 0, 0, 0.2);
+}

--- a/theme/js/rawpheno.admin.script.js
+++ b/theme/js/rawpheno.admin.script.js
@@ -57,6 +57,16 @@
       });
 
 
+      // Add event listener to Genus.
+      $('.more-info')
+        .mouseover(function() {
+          $(this).next().show();
+        })
+        .mouseout(function() {
+          $(this).next().hide();
+        });
+
+
       // Add event listener to user my folder.
       $('.link-show-folder').click(function(e) {
         e.preventDefault();

--- a/theme/rawpheno_pages.tpl.php
+++ b/theme/rawpheno_pages.tpl.php
@@ -108,6 +108,18 @@
       print tripal_set_message('Administrators, you can create or configure Phenotyping Projects by clicking the link below: <br />' . $link_to_manage_project, TRIPAL_INFO, array('return_html' => TRUE));
       unset($form);
     }
+    elseif (!$has_genus) {
+      // A project has no genus defined.
+    ?>
+      <div id="container-no-info" class="messages warning">
+        A project(s) has no genus defined. Please contact the administrator of this website.
+      </div>
+    <?php
+     // Admin: Create and configure projects:
+      $link_to_manage_project = l('Rawphenotypes: Manage Project', '/admin/tripal/extension/rawphenotypes');
+      print tripal_set_message('Administrators, you can assign an genus to a project by clicking the link below: <br />' . $link_to_manage_project, TRIPAL_INFO, array('return_html' => TRUE));
+      unset($form);
+    }
     elseif (!$has_data AND in_array($page_id, array('rawpheno_rawdata', 'rawpheno_download'))) {
       // Has project but project has no data associated to it.
       // Excempt pages upload, backup and instructions.


### PR DESCRIPTION
Stock names look up - limits the list of stocks used to verify name column header in data collection spreadsheet file.

I have created a function to check if a given project has a genus set in project admin by searching a record in projectprop. It can return project genus, as well as the organisms in a project genus or return nothing when none is found.

In validation process, the function will return the organisms (organism_id) which will then become part of the sql query (IN() clause) to limit the stocks to only the organisms in a project genus.

To test this validation:
1. AGILE collecting for Lens - in a blank agile spreadsheet add a row and set the name to Divine. This should return an non-existent organism because Divine belongs to Vicia genus.

2. Create a project set genus to Pisum add one existing trait - in a blank spreadsheet in instructions page, add a row and set the name to a Pisum stock: Racer. I have inserted the same stock but into Lotus genus. Although we both have 2 copies of the same stock, uploading the spreadsheet should be error free since Racer is unique to Pisum and Lotus.

3. In the same project with Pisum genus - in a blank spreadsheet in instructions page, add a row and set the name to stockxyz. This specific stock is a Pisum stock but is in both Fulvum and Sativum organisms (both Pisum organism). The result should instruct user that germplasm is not unique.

Hope my terminologies make sense :)