### PR TITLE
Failed to add new traits in rawphenotypes manged project.

### DIFF
--- a/rawpheno.install
+++ b/rawpheno.install
@@ -692,6 +692,68 @@ function rawpheno_uninstall() {
 
 /**
  * Implements hook_update_N().
+ * Map cvterm in tripal database to rawpheno_tripal.
+ *
+ * N
+ * 7  - Drupal core compatibility.
+ * 2  - Module's major release version.
+ * 01 - Sequence count.
+ */
+function rawpheno_update_7201() {
+  // Rawphenotypes database name.
+  $rawpheno_dbname = 'rawpheno_tripal';
+  // db_id
+  $rawpheno_dbid = '';
+
+  // In db table, check to see if rawpheno_tripal exists.
+  $sql = "SELECT db_id FROM {db} WHERE name = :rawpheno_dbname LIMIT 1";
+  $args = array(':rawpheno_dbname' => $rawpheno_dbname);
+
+  $db_id = chado_query($sql, $args);
+
+  if ($db_id->rowCount()) {
+    // Already created. Save the db_id
+    $rawpheno_dbid = $db_id
+      ->fetchField();
+  }
+  else {
+    // Not created. Insert a row and get the id.
+    $db_id = chado_insert_record('db', array('name' => $rawpheno_dbname));
+    $rawpheno_dbid = $db_id['db_id'];
+  }
+
+  // Get the db id of Tripal db. Use it to futher filter the rows for update
+  // since previous version use tripal as default db.
+  $sql = "SELECT db_id FROM {db} WHERE name = 'tripal' LIMIT 1";
+  $tripal = chado_query($sql);
+
+  if ($tripal->rowCount()) {
+    $tripal_dbid = $tripal
+      ->fetchField();
+
+    // With the db_id, update all rawphenotypes cvterms to use this db_id in dbxref.
+    $t = rawpheno_function_terms('vocabularies');
+    unset($t['cv_rver'], $t['cv_desc']);
+    $terms = array_values($t);
+
+    // Update db_id in dbxerf table. Map all rawphenotypes cvterms to rapheno_tripal db.
+    $sql = "
+      UPDATE {dbxref} SET db_id = :rawpheno_dbid
+      WHERE
+        dbxref_id IN (SELECT t2.dbxref_id FROM {cv} AS t1 INNER JOIN {cvterm} AS t2 USING (cv_id) WHERE t1.name IN (:terms))
+        AND db_id = :tripal_dbid";
+
+    $args = array(':rawpheno_dbid' => $rawpheno_dbid, // Map to rawpheno_tripal instead.
+                  ':terms' => $terms,                 // Only for terms phenotype_plant_property, phenotype_measurement_units and phenotype_measurement_type
+                  ':tripal_dbid' => $tripal_dbid);    // Where previously set to TRIPAL.
+
+    chado_query($sql, $args);
+  }
+}
+
+
+/**
+ * Implements hook_update_N().
  * Update custom table with tables relating a project to set of cvterms
  * and project to stock/name.
  *


### PR DESCRIPTION
`PDOException: SQLSTATE[23505]: Unique violation: 7 ERROR: duplicate key value violates unique constraint "dbxref_pkey" DETAIL: Key (dbxref_id)=(3386965) already exists.: INSERT INTO chado.dbxref (db_id, accession, version, description) VALUES (:db_id, :accession, :version, :description); Array ( [:db_id] => 662 [:accession] => Days till 50% of plant have one open flower (R1; days) [:version] => [:description] => ) in chado_query() (line 1538 of /var/www/portal/sites/all/modules/contrib/tripal/tripal_core/api/tripal_core.chado_query.api.inc).`

Error above show in the error log when adding a new column header in the project management page. On initial review of code, it shows that when inserting a cvterm a counter points to an existing dbxref_id hence the duplicate key error. Examining terms in the portal show that they have been inserted in db - tripal instead of db - rawpheno_tripal. I suspect that the traits were inserted in the first release and recent updates did not include a function to map them to the correct db. Furthermore, @laceysanderson thinks that this db discrepancy is causing sequence counter/serial number in tripal_insert_cvterm() to return incorrect count.

This is a suggested fix. Although fresh reflects portal, adding new headers to it causes no error.

I have tested the upadate by 
1. Uninstalling the module.
2. Deleted rawpheno_tripal in chado.db
3. Replaced rawpheno_tripal to tripal in all instance of tripal_insert_cvterm()
in .install file.

    $cvterm = tripal_insert_cvterm(
      array(
        'id'         => 'tripal:' . $header, // 'replace back to rawpheno_tripal:' 
        'name'       => $header,
        'definition' => $cvterm_definition,
        'cv_name'    => $cvterm_type
      )
    );
  
This will replicate the db source of terms in the portal.

4. re-Installed the module.
  All module cvtem should be linked to tripal db.  
  To check, view a vocabulary term and see the database details below.
5. Run update. 
  Should map all module cvterms to rawpheno_tripal.
  To check, view a vocabulary term and see the database details below.
6. Added a new term.
7. Revert the changes (step 3) in .install file.

Thanks!