### PR TITLE
Issue #23 - Allow Not Applicable values (n/a, na or n.a.).

### DIFF
--- a/include/rawpheno.function.measurements.inc
+++ b/include/rawpheno.function.measurements.inc
@@ -394,6 +394,7 @@ function rawpheno_function_create_json($project_id, $trait_id, $type, $option, $
 
     // Size of each bin/ interval.
     $interval = round($max/$total_bins);
+    $stock_bin = 0;
 
     $i = 0;
     $to = 0;

--- a/include/rawpheno.upload.excel.inc
+++ b/include/rawpheno.upload.excel.inc
@@ -237,6 +237,9 @@ function rawpheno_load_spreadsheet($project_id, $arr_newheaders, $fid, $plantpro
 
           // Get the column header of a cell.
           $cell_colheader = trim(str_replace(array("\n", "\r", "  "), ' ', $header[$cell_index]));
+          // Remove additional spaces from column headers.
+          $cell_colheader = preg_replace('/\s+/', ' ', $cell_colheader);
+
 
           // Determine if user wants to save this trait.
           if (count($arr_newheaders) > 0 AND array_key_exists($cell_colheader, $arr_newheaders)) {
@@ -967,16 +970,16 @@ function rawpheno_get_trait_unit($trait_name, $trait_id = NULL) {
 
   // First we try to get the unit through relationships since that avoids making assumptions.
   // in chado.cvterm_relationship.
-  $sql = "SELECT rel.object_id as id, cvt.name as name
+  $sql = "SELECT rel.subject_id as id, cvt.name as name
           FROM chado.cvterm_relationship rel LEFT JOIN chado.cvterm cvt ON cvt.cvterm_id = rel.object_id
-          WHERE rel.subject_id = :trait LIMIT 1";
+          WHERE rel.object_id = :trait LIMIT 1";
 
   $args = array(':trait' => $trait_id);
   $unit = db_query($sql, $args)
-    ->fetchAll();
+    ->fetchObject();
 
-  if (sizeof($unit) == 1) {
-    return $unit[0];
+  if ($unit) {
+    return array('id' => $unit->id, 'name' => $unit->name);
   }
 
   // If that doesn't work then we try to extract it from the name.

--- a/include/rawpheno.upload.excel.inc
+++ b/include/rawpheno.upload.excel.inc
@@ -73,6 +73,9 @@ function rawpheno_load_spreadsheet($project_id, $arr_newheaders, $fid, $plantpro
   $tmp = file_directory_temp();
   $filename = $tmp . '/' . 'job-progress' . $job_id . '.txt';
 
+  // Variations of Not Applicable.
+  $not_applicable = array('na', 'n/a', 'n.a.');
+
   // Start Transaction.
   $TRANSACTION = db_transaction();
   try {
@@ -223,6 +226,11 @@ function rawpheno_load_spreadsheet($project_id, $arr_newheaders, $fid, $plantpro
       // Read each row and each cell.
       // Each row will be an array where name is always the first element.
       foreach($row as $cell_index => $cell_entry) {
+        // For consistency, convert all variations of not applicable to NA.
+        if (is_string($cell_entry) && in_array(strtolower($cell_entry), $not_applicable)) {
+          $cell_entry = 'NA';
+        }
+
         // We don't want to insert empty data.
         // That said, while PHP thinks 0 is empty, we do not.
         if (!empty($cell_entry) OR (strval($cell_entry) === '0')) {
@@ -300,7 +308,7 @@ function rawpheno_load_spreadsheet($project_id, $arr_newheaders, $fid, $plantpro
           }
           // THE REST OF THE COLUMN HEADERS
           // Everything else into pheno_measurements.
-          elseif (!empty($cell_colheader)) {
+          elseif (!empty($cell_colheader) && $cell_entry != 'NA') {
             // Get the cvterm_id for the trait measurement.
             $type_id = rawpheno_get_trait_id($cell_colheader);
 
@@ -520,6 +528,9 @@ function rawpheno_validate_excel_file($file, $project_id, $source) {
   // XLS starts at 1, while XLSX at 0;
   $i = 0;
 
+  // Variations of Not Applicable.
+  $not_applicable = array('na', 'n/a', 'n.a.');
+
   // Iterate though each row.
   $num_errored_rows = 0;
   $storage = array();
@@ -588,6 +599,11 @@ function rawpheno_validate_excel_file($file, $project_id, $source) {
           // We always want to strip flanking white space.
           // FYI: This is done when the data is loaded as well.
           $cell = trim($cell);
+
+          // For consistency, convert all variations of not applicable to NA.
+          if (is_string($cell) && in_array(strtolower($cell), $not_applicable)) {
+            $cell = 'NA';
+          }
 
           // Foreach validator:
           foreach (array('all','subset') as $scope) {

--- a/include/rawpheno.upload.form.inc
+++ b/include/rawpheno.upload.form.inc
@@ -1027,7 +1027,7 @@ function rawpheno_submit_review($form, &$form_state) {
 
       // Determine if the form in review traits has been filled out and checkbox
       // has been checked by user. If it has been checked then save the trait.
-      if ($form_state['values']['chk_' . $i] === 1) {
+      if ($form_state['values']['chk_' . $i] === 1 && !empty($form_state['values']['txt_header_' . $i])) {
         // Before save, we need to tell if the header is present in the database and
         // user just wants to reuse them. Otherwise, add a new header.
         // Reuse header - set to OPTIONAL.
@@ -1068,6 +1068,8 @@ function rawpheno_submit_review($form, &$form_state) {
         // Add the as contributed - set to CONTRIBUTED.
         // Construct the column header name.
         $name   = trim($form_state['values']['txt_header_' . $i]);
+        $name   = preg_replace('/\s+/', ' ', $name);
+
         $unit   = trim($form_state['values']['txt_unit_' . $i]);
         $method = trim($form_state['values']['txtarea_describe_' . $i]);
         $def    = trim($form_state['values']['txt_def_' . $i]);

--- a/include/rawpheno.validation.inc
+++ b/include/rawpheno.validation.inc
@@ -366,36 +366,46 @@ function validator_required_info_generate_msg($error_info) {
  *   TRUE if it passed validation; FALSE otherwise.
  */
 function validator_required_info_validate_cell($value, $context, &$storage) {
+  if ($context['header'][ $context['column index'] ]['no format'] == 'name' ||
+      $context['header'][ $context['column index'] ]['no format'] == 'plantingdate(date)') {
 
-  // Validate if the cell is empty.
-  if (empty($value)) return array('code' => 1, 'row' => $context['row index']);
-  if ($value < 0) return array('code' => 1, 'row' => $context['row index']);
+    // Planting date and Name (germplasm) remain required - no NAs allowed.
+    if (empty($value)) {
+      return array('code' => 1, 'row' => $context['row index']);
+    }
+  }
+  else {
+    // All else, but plot has extra step.
+    if (empty($value) || $value < 0) {
+      return array('code' => 1, 'row' => $context['row index']);
+    }
 
-  // Validate if the plot is unique.
-  // If this is the plot column...
-  if ($context['header'][ $context['column index'] ]['no format'] == 'plot') {
-    // Get Planting date (date) and location index from the header rows.
-    $planting_date_i = $context['plot_req']['planting date (date)'];
-    $location_i = $context['plot_req']['location'];
+    // Is this plot?
+    // Skip duplicate plot check when value is NA.
+    if ($context['header'][ $context['column index'] ]['no format'] == 'plot' && $value != 'NA') {
+      // Get Planting date (date) and location index from the header rows.
+      $planting_date_i = $context['plot_req']['planting date (date)'];
+      $location_i = $context['plot_req']['location'];
 
-    // Get the cell value of header idexes.
-    // Extract the year (YYYY) from planting year (date)
-    $planting_date = $context['row'][$planting_date_i];
-    $planting_year = substr($planting_date, 0, 4);
+      // Get the cell value of header idexes.
+      // Extract the year (YYYY) from planting year (date)
+      $planting_date = $context['row'][$planting_date_i];
+      $planting_year = substr($planting_date, 0, 4);
 
-    // Location
-    $location = trim($context['row'][$location_i]);
+      // Location
+      $location = trim($context['row'][$location_i]);
 
-    // Has this value been used before? value being (year+location+plot)
-    $rows_used_in = array_keys($storage, $planting_year . $location . $value);
+      // Has this value been used before? value being (year+location+plot)
+      $rows_used_in = array_keys($storage, $planting_year . $location . $value);
 
-    // save to storage.
-    $storage[ $context['row index'] ] = $planting_year . $location . $value;
+      // save to storage.
+      $storage[ $context['row index'] ] = $planting_year . $location . $value;
 
-    // if it has then save for error.
-    if ($rows_used_in) {
-      $rows_used_in[] = $context['row index'];
-      return array('code' => 2, 'value' => $value, 'rows' => $rows_used_in);
+      // if it has then save for error.
+      if ($rows_used_in) {
+        $rows_used_in[] = $context['row index'];
+        return array('code' => 2, 'value' => $value, 'rows' => $rows_used_in);
+      }
     }
   }
 
@@ -486,8 +496,10 @@ function validator_units_match_type_validate_cell($value, $context, &$storage) {
   // Determine the units for this column.
   $unit = $context['header'][ $context['column index'] ]['units'];
 
-  // We always want to allow empty cells but not treat zero as empty...
-  if (empty($value) AND !(strval($value) === '0')) {
+  // We always want to allow empty cells or NA but not treat zero as empty...
+  if ((empty($value) AND !(strval($value) === '0')) ||
+      ($value == 'NA' && $context['header'][ $context['column index'] ]['no format'] != 'plantingdate(date)')) {
+
     return TRUE;
   }
 


### PR DESCRIPTION
Data collectors encounter difficulty submitting data due to cell values containing different variations of Not Applicable (na, n/a). Recently, a spreadsheet file containing information that requires some column headers be set to Not Applicable has to be submitted to the server. This update will allow such requirements into the system.

Fixes:
During validation of cell values (in file_validate hook and validate_excel_file), any instance of  not applicable value is converted first to NA for consistency (module uses NA variation for processing, downloading and storing data). Next, the NA value is then submitted to registered validators (of scope all and subset) to check if phenotype it is in permits such value or not. A validation error is generated when column is set to not allow NA. Otherwise user is instructed to proceed to next stage of the process.

Please note that this update applies to backup as well, since both upload and backup use the same set of validators.

Testing:
1. Download/Prepare a standard phenotyping spreadsheet file.
2. Add na, NA, n/a, N/A, n.a, or N.A. to any phenotype except Planting Date and Name (germplasm) columns.
3. Upload or backup the file.
4. To test errors: set value to naa, n*a, naaa or other character values that do not match NA, N/A, N.A., regardless of the case.

Please Note: Planting Date and Name remain required column - must have value, YYYY-MM-DD for planting date and no NAs allowed.