### PR TITLE
Issue #31 - Bug fixes

### DIFF
--- a/include/rawpheno.admin.form.inc
+++ b/include/rawpheno.admin.form.inc
@@ -1774,11 +1774,16 @@ function rawpheno_admin_render_form_trait($form, &$form_state, $default) {
   $unit = chado_query($sql)
     ->fetchAllKeyed();
 
+  // Default to text unit.
+  $unit_keys = array_keys($unit);
+  $textunit = array_search('text', $unit_keys);
+  $textunit_id = $unit_keys[$textunit];
+
   $form['fieldset_trait']['sel_trait_unit'] = array(
     '#type' => 'select',
     '#title' => t('Unit:'),
     '#options' => $unit,
-    '#default_value' => isset($default['sel_trait_unit']) ? $default['sel_trait_unit'] : reset($unit),
+    '#default_value' => isset($default['sel_trait_unit']) ? $default['sel_trait_unit'] : $textunit_id,
     '#disabled' => $disabled,
   );
 

--- a/include/rawpheno.admin.form.inc
+++ b/include/rawpheno.admin.form.inc
@@ -451,7 +451,7 @@ function rawpheno_admin_all_projects_submit($form, &$form_state) {
 
 
   // Redirect user to project asset management page.
-  $path = url('../../admin/tripal/extension/rawphenotypes/all_projects/' . $project_id . '/project/manage');
+  $path = url($GLOBALS['base_url'] . '/admin/tripal/extension/rawphenotypes/all_projects/' . $project_id . '/project/manage');
   drupal_goto($path);
 }
 
@@ -1369,7 +1369,7 @@ function rawpheno_admin_project_headers($form, $form_state, $header_asset, $acti
     }
   }
   elseif ($action == 'delete') {
-    $path = url('../../admin/tripal/extension/rawphenotypes/all_projects/' . $header_asset['in_project_id'] . '/project/manage');
+    $path = url($GLOBALS['base_url'] . '/admin/tripal/extension/rawphenotypes/all_projects/' . $header_asset['in_project_id'] . '/project/manage');
 
     // Admin wants to delete/remove the trait from the project.
     db_delete('pheno_project_cvterm')
@@ -1630,7 +1630,7 @@ function rawpheno_admin_project_management_submit($form, &$form_state) {
  */
 function rawpheno_admin_project_users($form, $form_state, $user_project_asset, $action) {
   if ($action == 'delete') {
-    $path = url('../../admin/tripal/extension/rawphenotypes/all_projects/' . $user_project_asset['project_id'] . '/project/manage');
+    $path = url($GLOBALS['base_url'] . '/admin/tripal/extension/rawphenotypes/all_projects/' . $user_project_asset['project_id'] . '/project/manage');
 
     db_delete('pheno_project_user')
       ->condition('project_user_id', $user_project_asset['project_user_id'])
@@ -1681,7 +1681,7 @@ function rawpheno_admin_project_envdata($form, $form_state, $envdata_project_ass
     }
 
     // Redirect user.
-    $path = url('../../admin/tripal/extension/rawphenotypes/all_projects/' . $envdata_project_asset['project_id'] . '/project/manage');
+    $path = url($GLOBALS['base_url'] . '/admin/tripal/extension/rawphenotypes/all_projects/' . $envdata_project_asset['project_id'] . '/project/manage');
     drupal_goto($path);
   }
 }

--- a/include/rawpheno.upload.excel.inc
+++ b/include/rawpheno.upload.excel.inc
@@ -932,7 +932,10 @@ function rawpheno_count_rows($xls_obj) {
  *   The cvterm_id for the trait.
  */
 function rawpheno_get_trait_id($header) {
-  $header = str_replace(array("\n", "\r", "  "), ' ', $header);
+  // New lines.
+  $header = str_replace(array("\n", "\r"), ' ', $header);
+  // Extra spaces.
+  $header = preg_replace('!\s+!', ' ', $header);
 
   // Query trait. Module stores unit in lowercase but user can use any case
   // in the spreadsheet. eg Planting Date (date) and Planting Date (Date).

--- a/include/rawpheno.upload.excel.inc
+++ b/include/rawpheno.upload.excel.inc
@@ -862,6 +862,7 @@ function rawpheno_indicate_new_headers($file, $project_id) {
       // Determine if column header exists in the expected column headers.
       if (!in_array($temp_value, $expected_headers) && !empty($value)) {
         // Not in expected column headers, save it as new header.
+        $value = preg_replace('/\s+/', ' ', $value);
         $new_headers[] = $value;
       }
     }

--- a/include/rawpheno.upload.form.inc
+++ b/include/rawpheno.upload.form.inc
@@ -359,7 +359,7 @@ function rawpheno_upload_form_stage_review(&$form, &$form_state) {
         );
 
         // Clean up the current header.
-        $name = rawpheno_function_delformat($k);
+        $name = trim(strtolower(preg_replace('!\s+!', ' ', $k)));
         $arr_checked_header[] = $name;
 
         // Test if the header has a unit component and set the variable accordingly.
@@ -449,7 +449,7 @@ function rawpheno_upload_form_stage_review(&$form, &$form_state) {
             '#description' => t('A human-readable text definition'),
           );
 
-           if (isset($cvterm_info)) {
+           if (isset($cvterm_info) && isset($cvterm_info->definition)) {
              $form['xls_review_fldset']['fldset_' . $i]['txt_def_' . $i]['#value'] = $cvterm_info->definition;
              $form['xls_review_fldset']['fldset_' . $i]['txt_def_' . $i]['#disabled'] = TRUE;
            }

--- a/include/rawpheno.upload.form.inc
+++ b/include/rawpheno.upload.form.inc
@@ -1023,6 +1023,8 @@ function rawpheno_submit_review($form, &$form_state) {
       // For each new header store information provided in the interface.
       // Indicates if user has check this header for saving.
       $header = trim(str_replace(array("\n", "\r", "  "), ' ', $header));
+      $header = preg_replace('/\s+/', ' ', $header);
+
       $arr_newheaders[$header]['flag'] = ($form_state['values']['chk_' . $i] == 1) ? 1 : 0;
 
       // Determine if the form in review traits has been filled out and checkbox

--- a/include/rawpheno.validation.inc
+++ b/include/rawpheno.validation.inc
@@ -112,7 +112,11 @@ function validator_is_excel_validate_file($file) {
 
   // First test extension.
   $xls_extension = pathinfo($file->filename, PATHINFO_EXTENSION);
-  if ($xls_extension == 'xlsx' OR $xls_extension == 'xls') {
+  $xls_mime = $file->filemime;
+
+  if (($xls_extension == 'xlsx' OR $xls_extension == 'xls') &&
+      ($xls_mime == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+       OR $xls_mime == 'application/vnd.ms-excel')) {
 
     // Then test that the file can be opened.
     // This checks against PDFs masquerading as XLS ;-).


### PR DESCRIPTION
- Page not found page redirect error
FIX: made the system generate the url instead of hard-coding it. This way, the module can correctly point to the right url when folder structure is different from dev version.
TO TEST: Create a test project in your dev and add header, user and environment data file to it. After adding, delete each one of them. In all delete/remove operation, the page should reload itself and not redirect to a page not found.
NOTE: This cannot be tested on the portal since there is no option to delete a project once you do testing to it.

- Not suggesting a trait in stage 2 - describe trait
FIX: remove leading and trailing space to the trait.
TO TEST: Upload a spreadsheet file that contains a trait that is in another project. Click next to stage 2 where a field "Did you mean" will provide you an option of similar traits.

- Extra spaces in column headers
FIX: replaced any multiple spaces in column headers into single space.
TO TEST: Upload a spreadsheet file with a column header with multiple spaces 
eg. Plant     height   (cm), Days       till     10% of Plants have     One Open Flower

- Non-MS Excel spreadsheet
FIX: Added a check to see if spreadsheet file matched MS Excel MIME information.
TO TEST: Use the file attached.
[LibreOffice Spreadsheet.xlsx](https://github.com/UofS-Pulse-Binfo/rawphenotypes/files/1704576/LibreOffice.Spreadsheet.xlsx)

