### PR TITLE
Issue # 15 - Fixed bug in allow backup of file with missing measurements tab.

### DIFF
--- a/include/rawpheno.upload.form.inc
+++ b/include/rawpheno.upload.form.inc
@@ -875,6 +875,12 @@ function rawpheno_file_validate($file) {
 
     $s = (isset($flags['status'])) ? $flags['status'] : $flags;
 
+    // If DND backup, missing measurements, skip all validator but
+    // save/backup the file anyway.
+    if ($s['tab_exists'] === FALSE) {
+      return array();
+    }
+
     // Read only the status from test listed above.
     foreach($s as $i => $v) {
       if (in_array($i, $flag_index) AND ($v === FALSE || $v === 'todo')) {


### PR DESCRIPTION
This update to Backup functionality will allow data collectors to back up spreadsheet file with no measurements (tab missing or renamed).

To test:
1. Load backup page.
2. Select a project
3. Enter data to the spreadsheet file below:
[NO Measurements Tab.xlsx](https://github.com/UofS-Pulse-Binfo/rawphenotypes/files/1891521/NO.Measurements.Tab.xlsx)
then Drag and Drop or manual upload.
4. Type comments/notes.
5. Click Upload button.

Validation Result for file with missing measurements tab.
![missing tab validation result](https://user-images.githubusercontent.com/15472253/38520085-eeed4ffa-3bfe-11e8-8857-1a72b3a398dd.png)

