### PR TITLE
Issue #43 - Removed extra whitespaces in column headers (essential, subset etc.)

### DIFF
--- a/include/rawpheno.function.measurements.inc
+++ b/include/rawpheno.function.measurements.inc
@@ -1160,7 +1160,7 @@ function rawpheno_function_plot_exists($plot, $project_id) {
       AND t2.type_id = (SELECT cvterm_id FROM {cvterm} cvt LEFT JOIN {cv} ON cv.cv_id=cvt.cv_id WHERE cvt.name = 'Plot' AND cv.name = 'phenotype_plant_property_types')
       AND t3.type_id = (SELECT cvterm_id FROM {cvterm} cvt LEFT JOIN {cv} ON cv.cv_id=cvt.cv_id WHERE cvt.name = 'Rep' AND cv.name = 'phenotype_plant_property_types')
       AND t4.type_id = (SELECT cvterm_id FROM {cvterm} cvt LEFT JOIN {cv} cv ON cv.cv_id=cvt.cv_id WHERE cvt.name = 'Location' AND cv.name = 'phenotype_plant_property_types')
-      AND t5.type_id = (SELECT cvterm_id FROM {cvterm} cvt LEFT JOIN {cv} ON cv.cv_id=cvt.cv_id WHERE name = 'Planting Date (date)' AND cv.name = 'phenotype_measurement_types')
+      AND t5.type_id = (SELECT cvterm_id FROM {cvterm} cvt LEFT JOIN {cv} ON cv.cv_id=cvt.cv_id WHERE cvt.name = 'Planting Date (date)' AND cv.name = 'phenotype_measurement_types')
       AND
         t1.stock_id || '-' ||
         t2.value    || '-' ||

--- a/include/rawpheno.upload.excel.inc
+++ b/include/rawpheno.upload.excel.inc
@@ -330,7 +330,8 @@ function rawpheno_load_spreadsheet($project_id, $arr_newheaders, $fid, $plantpro
           // THE REST OF THE COLUMN HEADERS
           // Everything else into pheno_measurements.
           elseif (!empty($cell_colheader) && $cell_entry != 'NA') {
-            if (in_array($cell_colheader, $skip)) {
+            $c_h = rawpheno_function_delformat($cell_colheader);
+            if (in_array($c_h, $skip)) {
               // print 'skipping header : ' . $cell_colheader . "\n";
               continue;
             }
@@ -592,7 +593,14 @@ function rawpheno_validate_excel_file($file, $project_id, $source) {
           // based on headers in drupal_alter hook.
           $s = (in_array($without_format, $skip)) ? 1 : 0;
 
+          // Remove new lines.
+          $rem_newline = str_replace(array("\n", "\r"), ' ', $r);
+          // Remove extra spaces.
+          $rem_spaces  = preg_replace('/\s+/', ' ', $rem_newline);
+          // Remove leading and trailing spaces.
+          $r = trim($rem_spaces);
           $no_units = rawpheno_get_trait_name($r);
+
           $header[] = array(
             'no format' => $without_format,
             'original' => $r,
@@ -602,7 +610,7 @@ function rawpheno_validate_excel_file($file, $project_id, $source) {
           );
 
           // Store index number of Plot trait requirements.
-          if (!isset($plot_req['planting date (date)']) && $without_format == 'planting date (date)') {
+          if (!isset($plot_req['planting date (date)']) && $without_format == 'plantingdate(date)') {
             $plot_req['planting date (date)'] = $o;
           }
           elseif (!isset($plot_req['location']) && $without_format == 'location') {

--- a/theme/js/rawpheno.upload.stage01.js
+++ b/theme/js/rawpheno.upload.stage01.js
@@ -17,7 +17,7 @@
       }
 
      if ($('#float-text').length) {
-       $('#rawpheno-select-project-field').click(function(e) {
+       $('#rawpheno-select-project-field').mousedown(function(e) {
          $('#float-text').remove();
        });
      }


### PR DESCRIPTION
Remove extra whitespaces in non new or additional column headers.

To test:
- Upload a spreadsheet file with whitespaces in column headers (essential, subset etc.).

Minor update included in this request:
- Fixed SQL ambiguous field error.
- Modified listener to select project field in upload to clear select project reminder.
Currently, select project field has to be clicked, select a value only then the reminder clears. With this new event listener reminder clears the instant select field is clicked.