### PR TITLE
updated pattern to allow optional chars at the end of trait string

### DIFF
--- a/include/rawpheno.function.measurements.inc
+++ b/include/rawpheno.function.measurements.inc
@@ -1017,8 +1017,9 @@ function rawpheno_valid_trait_format($trait) {
   if (preg_match('/[(|)]/', $trait) === 1 && $trait != 'Lodging (Scale: 1-5) upright - lodged') {
     // With these characters present, test if the format is trait name (unit).
 
-    // Pattern: first string can be any chars but ( and ) followed by 0 or more space then 1 ( then any chars and ) as the end of string.
-    $is_valid = (preg_match('/\A[^()]+\s*\({1}[^)(]+\)\z/i', $trait) === 1) ? TRUE : FALSE;
+    // Pattern: first string can be any chars but ( and ) followed by 0 or more space then 1 ( then any chars and )
+    // plus optional any chars but ( and ) as the end of string.
+    $is_valid = (preg_match('/\A[^()]+\s*\({1}[^)(]+\)[^)(]*\z/i', $trait) === 1) ? TRUE : FALSE;
   }
 
   return $is_valid;

--- a/include/rawpheno.upload.form.inc
+++ b/include/rawpheno.upload.form.inc
@@ -480,7 +480,11 @@ function rawpheno_upload_form_stage_review(&$form, &$form_state) {
           }
           else {
             if ($has_unit == 'yes') {
-              $form['xls_review_fldset']['fldset_' . $i]['txt_unit_' . $i]['#value'] = trim(strpbrk($name, '()'), '()');
+              $u = strpbrk($name, '()');
+              // Remove any parenthesis making its way to the final value.
+              $u = str_replace(array('(', ')'), '', $u);
+
+              $form['xls_review_fldset']['fldset_' . $i]['txt_unit_' . $i]['#value'] = trim($u);
               $form['xls_review_fldset']['fldset_' . $i]['txt_unit_' . $i]['#disabled'] = FALSE;
             }
           }


### PR DESCRIPTION
- The pattern ensures that in any given trait string there can only be
one unit portion enclosed in parenthesis.

To test the pattern:

$trait = array(
 'Distribution (1st; count)',
 'Distribution (2nd; count)',
 'Nodule Colour (scale)',
 'Nodule Dry Weight (g)',
 'Shoot Dry Weight (g)',
 'Root Dry Weight (g)',
 'Average Number of Pods per plant (cm)',
 'Yield (g)',
 'Nitrogen Content (g)',
 'Leghemoglobine Content (cm)',
 'Days of 50% Flowering (number)',
 'Subset Traits: # Seeds (count)',
 'Node at first flower (count)',
 'Species (text)',
 'Gene Pool (text)',
 'Dead Plants (number)',
 'Cold stress (scale: 0-3)',
 'R7 Traits: Canopy Width (1st; cm)',
 'R7 Traits: Canopy Width (2nd; cm)',
 'R7 Traits: Plant Length (1st; cm)',
 'R7 Traits: Plant Length (2nd; cm)',
 'Total Peduncles Counted (count)',
 'Days till 1st Plant has Elongated Tendrils (days)',
 'Days till 3rd Plant has Elongated Tendrils (days)',
 'Days till 1st Plant has One Open Flower (R1; days)',
 'Days till 3rd Plant has One Open Flower (R1; days)',
 'Days till 1st Plant has Pods (R3; days)',
 'Days till 3rd Plant has Pods (R3; days)',
 'Days till 1st Plant has fully Swollen Pods (R5; days)',
 'Days till 3rd Plant has fully Swollen Pods (R5; days)',
 'Days till 1st Plant has 1/2 Pods Mature (R7; days)',
 'Days till 3rd Plant has 1/2 Pods Mature (R7; days)',
 'Disease Score (scale)',
 'Red Pod Presence (present/absent)',
 'Stay Green (present/absent)',
 'Greenseeker (36 DAP; NDVI)',
 'Plant Length (1st; cm)',
 'Plant Length (2nd; cm)',
 'Node of First Flower (1st; count)',
 'Node of First Flower (2nd; count)',
 'Pods Per Peduncle (max; num)',
 'Tendril Presence (present/absent)',
 'Flower Color (present/absent)',
 'Single Plant Mass (1st; g)',
 'Single Plant Mass (2nd; g)',
 'Single Plant Mass (3rd; g)',
 'Single Plant Seeds Per Pod (1st; mean of 5; count)',
 'Single Plant Seeds Per Pod (2nd; mean of 5; count)',
 'Single Plant Seeds Per Pod (3rd; mean of 5; count)',
 'Single Plant Mass of Seed (1st; g)',
 'Single Plant Mass of Seed (2nd; g)',
 'Single Plant Mass of Seed (3rd; g)',
 'Date Harvested (date)',
 'Plants Harvested (count)',
 'Greenseeker (34 DAP; NDVI)',
 'Stem Color (present/absent)',
 'Leaf Color (scale)',
 'Plot Mass (g)',
 'Yellowing (present/absent)',
 'Node at first flower - 2nd plant (count)',
 'harvest date (date)',
 'initial disease date (days)',
 'initial disease score (score)',
 'disease score maturity (score)',
 'SdWt_DIRTY (grams)',
 'Sample Notes (note)',
 'post harvest notes (note)',
 'Disease at Maturity (Day 77)',
 'notes (notes)',
 'harvest notes (notes)',
 'postharvest notes (notes)',
 'Growth habit (Scale 1-5)',
 'SB 1st (Scale 1-10)',
 'SB 2nd (Scale 1-10)',
 'Mass of 1000 Seeds (g)',
 'Seed Diameter (mm)',
 'Seed Perimeter (mm)',
 'Cotyledon Color (nominal)',
 'Seed Area (mm2)',
 'Days till Flowering (days)',
 'Harvesting (days)',
 'SB-specific comments (text)',
 'Emergence date (date)',
 'Flowering date (date)',
 'Vigor before flowering (Scale 1-5)',
 'Stand before flowering (Scale 1-5)',
 'Flower colour (white/pink)',
 'Canopy Height at flowering stage (cm)',
 'Canopy Height at maturity stage (cm)',
 'General Podability (Scale 1-5)',
 'Lodging (Scale 1-5)',
 'Sterile/Fertile (S/F)',
 'SB 3rd (Scale 1-10)',
 'SB 4th (Scale 1-10)',
 'Comments (text)',
 'trait (123abc; 111abc: abc)',
 'trait (123abc; 111abc: abc) abc 123;',
 'trait (abc) (abc; abc)',
);

foreach($trait as $t) {
  $is_valid = (preg_match('/\A[^()]+\s*\({1}[^)(]+\)[^)(]*\z/i', $t) === 1) ? 'valid' : 'invalid';
  echo $t . ' - ' . $is_valid . "\n";
} 


Result shows support for all format we currently have and format we will recommend to a data collector. The last item where unit cannot be ascertained is still not allowed.