### PR TITLE
Replaced character used as delimiter

### DIFF
--- a/include/rawpheno.download.form.inc
+++ b/include/rawpheno.download.form.inc
@@ -252,7 +252,8 @@ function rawpheno_download_submit($form, &$form_state) {
   // Otherwise, it will be an associative array where location is both key and value.
   // Convert this to comma separated string when there's anything else set to 0 - for all locations.
   $loc = $form_state['values']['sel_location'];
-  $loc = (count($loc) > 0) ? implode(',', $loc) : 0;
+  // Location 1 + (and) Location 2 + .....
+  $loc = (count($loc) > 0) ? implode('+', $loc) : 0;
 
   // Trait select field.
   // Trait select field is an empty array - all traits.
@@ -271,7 +272,7 @@ function rawpheno_download_submit($form, &$form_state) {
   if (isset($env) && $env == 1) {
     // Ensure that project and location combination return an environment data file.
     $project = explode(',', $prj);
-    $location = explode(',', $loc);
+    $location = explode('+', $loc);
 
     $files = rawpheno_function_getenv($project, $location);
 

--- a/include/rawpheno.tripaldownload.inc
+++ b/include/rawpheno.tripaldownload.inc
@@ -75,9 +75,9 @@ function rawpheno_trpdownload_summarize_download($vars) {
       ->fetchCol(0);
   }
   else {
-    $location = explode(',', $location);
+    $location = explode('+', $location);
   }
-  $summary .= '<li> ' . count($location) . ' LOCATIONS: <br /><em>' . implode(', ', $location) . '</em></li>';
+  $summary .= '<li> ' . count($location) . ' LOCATIONS: <br /><em>' . implode(' - ', $location) . '</em></li>';
 
   // TRAITS:
   $traits = trim(str_replace('t=', '', $traits));
@@ -228,7 +228,7 @@ function rawpheno_trpdownload_generate_file($variables, $job_id = NULL) {
       ->fetchCol(0);
   }
   else {
-    $location = explode(',', $location);
+    $location = explode('+', $location);
   }
 
   // Traits


### PR DESCRIPTION
Replace comma symbol as delimiter for encoding location(s) selected in select location in download page. Symbol + is used to indicate this location plus this other location and so on.

To test:
- In download page, select location that has comma symbol. eg. Cordoba, Spain.