### PR TITLE
Wrap long location values

### DIFF
--- a/theme/css/rawpheno.rawdata.style.css
+++ b/theme/css/rawpheno.rawdata.style.css
@@ -120,6 +120,28 @@ rect {
   width: 120px;
 }
 
+/* Wrap long location text where country information
+ * and city/region information are in separate line
+ *
+ * The top line, ideally should contain country and
+ * the bottom line is for region/city information.
+ */
+.location-text-top {
+  font-weight: bold;
+  text-transform: uppercase;
+  fill: #000000;
+}
+
+.location-text-bottom {
+  font-weight: normal;
+  text-transform: none;
+  fill: #999999;
+}
+
+.location-text-top, .location-text-bottom {
+  stroke: none;
+}
+
 
 /* No Data */
 .chart-no-data {

--- a/theme/js/rawpheno.rawdata.script.js
+++ b/theme/js/rawpheno.rawdata.script.js
@@ -139,17 +139,27 @@
       var width, height, margin = {};
 
       // Chart margins.
+      // NOTE: THIS MARGIN IS FOR BOTH HEATMAP AND HISTOGRAM!
       margin.top = 40;
       margin.left = 90;
       margin.bottom = 80;
       margin.right = 30;
+
+      // Use this variable to increase or decrease
+      // the current margin bottom value and not affect
+      // the margin for the histogram.
+      // @see note above.
+
+      // Adjusted margin bottom to accommodate
+      // text wrapping of long location value.
+      marginAdjust = 30;
 
       // x axis scale.
       var x0, xAxis;
 
 	    // Height of the chart defined in the css rule for #container-rawdata.
       height = parseInt(divChartContainer.style('height'), 10);
-      chartDimension.height = height - margin.top - margin.bottom;
+      chartDimension.height = height - margin.top - (margin.bottom + marginAdjust);
 
       // Main svg canvas of the heat map.
       var svg;
@@ -655,7 +665,10 @@
         // Render scales
         x0.rangeRoundBands([0, chartDimension.width]);
         xAxis.scale(x0);
-        d3.select('#g-x-axis').call(xAxis);
+        d3.select('#g-x-axis')
+          .call(xAxis)
+          .selectAll('text')
+            .call(wrapWords);
       }
 
       // Render bar chart elements.
@@ -1193,6 +1206,39 @@
            .attr('class', 'win-loading')
            .html('Please wait...');
       }
+
+      // Wrap long text value and set the first line
+      // to bold and capitalized.
+      function wrapWords(text) {
+        text.each(function() {
+          // Reference text.
+          var text  = d3.select(this);
+          // Read the words in the text.
+          var words = text.text().split(',');
+
+          // Clear the text so no duplicate label shown.
+          text.text(null);
+
+          var word,
+            line = [],
+            lineNumber = 0,
+            lineHeight = 1.2 // ems
+            y = text.attr('y') - 10,
+            dy = parseFloat(text.attr('dy'));
+
+          while (word = words.pop()) {
+            text.append('tspan')
+              .attr('class', 'bp-tspan')
+              .attr('x', 0)
+              .attr('y', y)
+              .attr('dy', ++lineNumber * lineHeight + dy + 'em')
+              .text(word.trim())
+                .attr('class', function() {
+                  return (lineNumber - 1 == 0) ? 'location-text-top' : 'location-text-bottom';
+                });
+          }
+         });
+       }
     }
   };
 }(jQuery));


### PR DESCRIPTION
**Issue # 68 - Summary page update - wrap text in location**
Convert comma separated values in location into multiple lines where
the country information and city/region are in separate lines.

## Metadata
[https://github.com/UofS-Pulse-Binfo/rawphenotypes/issues/68]

- [X] I feel this PR is ready to be merged.
- [X] This PR is dependent upon
[https://github.com/UofS-Pulse-Binfo/rawphenotypes/pull/67]
Only because the master takes a while to load and merging this PR first will
load the summary chart faster and thus see the changes/update without unnecessary delays.

Documentation:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
I reused a code used by beanplot chart in AP that wraps text into separate lines.
Function wrapWords(text) added to attached JavaScript of rawdata page.

## Dependencies
[https://github.com/UofS-Pulse-Binfo/rawphenotypes/pull/67]

## Testing?
This update will only separate location value when a comma symbol is present. I've made two test cases where one showed Country first followed by city and another where the city preceded country information. In either format, the function separates the csv values in location into separate lines as expected. In upload page we can enforce either format as required.

sample results:
![screen shot 2018-10-03 at 3 44 02 pm](https://user-images.githubusercontent.com/15472253/46441284-4fb75d80-c723-11e8-8b39-ed807e001360.png)

![screen shot 2018-10-03 at 3 45 33 pm](https://user-images.githubusercontent.com/15472253/46441334-6cec2c00-c723-11e8-9120-49e2109f65c0.png)



- [ ] I tested on a generic Tripal Site
- [X] I tested on a KnowPulse Clone
  in dev/A
- [ ] This PR includes automated testing